### PR TITLE
fix: avoid duplicated camera live previews

### DIFF
--- a/src/components/camera-stream.ts
+++ b/src/components/camera-stream.ts
@@ -3,17 +3,57 @@ import type { TemplateResult } from 'lit';
 
 import type { HassEntity, HomeAssistant } from '../types';
 
-export function renderLiveCameraPreview(
+export function cameraSnapshotUrl(entity: HassEntity | undefined): string {
+  if (!entity) return '';
+  const entityPicture = String(entity.attributes?.entity_picture || '');
+  const accessToken = String(entity.attributes?.access_token || '');
+  const baseUrl = entityPicture
+    || (accessToken
+      ? `/api/camera_proxy/${entity.entity_id}?token=${encodeURIComponent(accessToken)}`
+      : '');
+  if (!baseUrl) return '';
+  const sep = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${sep}ts=${Date.now()}`;
+}
+
+export function cameraUsesLiveStream(entity: HassEntity | undefined): boolean {
+  const streamType = String(entity?.attributes?.frontend_stream_type || '');
+  const supportedFeatures = Number(entity?.attributes?.supported_features || 0);
+  return Boolean(
+    (streamType && streamType !== 'none' && streamType !== 'unknown')
+      || (supportedFeatures & 2) === 2
+  );
+}
+
+export function renderCameraPreview(
   hass: HomeAssistant,
   entity: HassEntity,
-  className = 'camera-preview camera-live',
+  alt: string,
+  className = 'camera-preview',
 ): TemplateResult {
+  if (!cameraUsesLiveStream(entity)) {
+    const snapshotUrl = cameraSnapshotUrl(entity);
+    return html`
+      <div class=${className}>
+        <img
+          alt=${alt}
+          src=${snapshotUrl}
+          style="width:100%;height:100%;object-fit:cover;display:block;"
+        >
+      </div>
+    `;
+  }
+
   return html`
-    <div class=${className}>
+    <div
+      class="${className} camera-live"
+      style="position:relative;overflow:hidden;display:block;aspect-ratio:3 / 2;min-height:100px;"
+    >
       <ha-camera-stream
         class="camera-stream"
         .hass=${hass}
         .stateObj=${entity}
+        style="position:absolute;inset:0;width:100%;height:100%;display:block;overflow:hidden;"
       ></ha-camera-stream>
     </div>
   `;

--- a/src/views/home.ts
+++ b/src/views/home.ts
@@ -5,6 +5,7 @@ import type { HassEntity, RenderedDevice } from '../types';
 import type { RenderContext } from '../render/context';
 import { renderImage, renderUserAvatar } from '../render/context';
 import { renderNav } from '../components/nav';
+import { renderCameraPreview } from '../components/camera-stream';
 import { renderMediaPlayer } from '../components/media-player';
 import { renderMaintenanceCard } from '../components/maintenance';
 import { renderWeather } from '../components/weather';
@@ -48,12 +49,11 @@ export function renderHomeView(
   const alarmIcon = alarmIconMap[alarmState] || 'mdi:shield-lock';
 
   const cameraCard = hasCamera ? (() => {
-    const accessToken = String(cameraState?.attributes?.access_token || '');
-    const snapshotUrl = accessToken ? `/api/camera_proxy/${cameraEntityId}?token=${encodeURIComponent(accessToken)}&ts=${Date.now()}` : '';
+    const cameraName = String(cameraState?.attributes?.friendly_name || cameraEntityId);
     return html`
       <section class="glass-card panel-camera" @click=${() => ctx.onHandleAction(cameraEntityId, 'more-info')}>
-        <div class="section-title"><h2>${cameraState?.attributes?.friendly_name || cameraEntityId}</h2></div>
-        <div class="camera-preview"><img alt="" src=${snapshotUrl}></div>
+        <div class="section-title"><h2>${cameraName}</h2></div>
+        ${renderCameraPreview(ctx.hass, cameraState!, cameraName)}
       </section>
     `;
   })() : nothing;

--- a/src/views/security.ts
+++ b/src/views/security.ts
@@ -4,6 +4,7 @@ import type { TemplateResult } from 'lit';
 import type { HassEntity, RenderedDevice } from '../types';
 import type { RenderContext } from '../render/context';
 import { renderPageShell } from '../components/page-shell';
+import { cameraUsesLiveStream, renderCameraPreview } from '../components/camera-stream';
 import { renderImage } from '../render/context';
 import { assetKeyForDomain, deviceStateLabel, selectedSkin, t } from '../utils';
 
@@ -39,22 +40,17 @@ function renderSecurityCards(ctx: RenderContext): TemplateResult | typeof nothin
 
   const cameraCards = cameras.map(entity => {
     const stateLabel = deviceStateLabel(entity.state, ctx.language);
-    const stateObj = ctx.hass.states?.[entity.entity_id];
-    const entityPicture = String(stateObj?.attributes?.entity_picture || '');
-    const accessToken = String(stateObj?.attributes?.access_token || '');
-    const baseUrl = entityPicture
-      || (accessToken
-        ? `/api/camera_proxy/${entity.entity_id}?token=${encodeURIComponent(accessToken)}`
-        : '');
-    const sep = baseUrl.includes('?') ? '&' : '?';
-    const snapshotUrl = baseUrl ? `${baseUrl}${sep}ts=${Date.now()}` : '';
+    const cameraName = String(entity.attributes?.friendly_name || entity.entity_id);
+    const previewLabel = cameraUsesLiveStream(entity)
+      ? (ctx.language?.startsWith('zh') ? '实时监控' : 'Live stream')
+      : t(ctx.language, 'snapshot');
     return html`
       <button class="camera-card" @click=${() => ctx.onHandleAction(entity.entity_id, 'more-info')}>
-        <div class="camera-preview"><img alt=${String(entity.attributes?.friendly_name || entity.entity_id)} src=${snapshotUrl}></div>
+        ${renderCameraPreview(ctx.hass, entity, cameraName)}
         <div class="camera-meta">
           <div>
-            <p class="device-name">${String(entity.attributes?.friendly_name || entity.entity_id)}</p>
-            <p class="muted">${t(ctx.language, 'snapshot')}</p>
+            <p class="device-name">${cameraName}</p>
+            <p class="muted">${previewLabel}</p>
           </div>
           <div class="status">${stateLabel}</div>
         </div>


### PR DESCRIPTION
### 类型 / Type

- [x] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

N/A

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | N/A |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | N/A |

### 描述 / Description

Prevent duplicated camera preview frames by making live stream and snapshot rendering mutually exclusive.

Changes:
- Render `ha-camera-stream` only for cameras that advertise a live frontend stream.
- Keep snapshot rendering for cameras without frontend stream support.
- Do not render a separate snapshot fallback under live streams, avoiding stacked/double video frames.
- Update Home CCTV and Security camera cards to use the shared renderer.

Local checks:
- `npm run build` passes.
- `git diff --check` passes.

### 附加信息 / Additional Info

This follows up PR #9 after reports that some cameras render duplicated frames when a live stream and snapshot layer are both present.

## Summary by Sourcery

Unify camera preview rendering to avoid duplicated live and snapshot frames and improve labeling of camera cards across Home and Security views.

New Features:
- Introduce a shared camera preview renderer that selects between live streams and snapshots based on camera capabilities.

Bug Fixes:
- Prevent duplicated camera frames by making live streaming and snapshot rendering mutually exclusive for the same camera.

Enhancements:
- Detect cameras that support frontend live streaming and use ha-camera-stream only for those entities.
- Display localized labels indicating whether a camera card is showing a live stream or a snapshot.
- Refine camera preview layout styling for consistent aspect ratio and sizing across views.