### PR TITLE
fix(skins): improve card text readability (batch 3/6)

### DIFF
--- a/skins-pro/happy-match/theme.css
+++ b/skins-pro/happy-match/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(255, 107, 157, 0.32), rgba(42, 16, 64, 0.62));
+  --sp-sidebar-bg: rgba(42, 16, 64, 0.88);
+  --sp-sidebar-text: #FFF5E6;
+  --sp-sidebar-text-muted: rgba(255, 245, 230, 0.68);
+  --sp-sidebar-active-bg: rgba(255, 107, 157, 0.26);
+  --sp-sidebar-active-text: #FF6B9D;
+  --sp-text-primary: #FFF5E6;
+  --sp-text-main: #FFF5E6;
+  --sp-text-muted: rgba(255, 245, 230, 0.82);
+  --sp-text-muted-bright: rgba(255, 245, 230, 0.82);
+  --sp-text-muted-dim: rgba(255, 245, 230, 0.82);
+  --sp-text-stage:#FFF5E6;
+  --sp-text-stage-muted:rgba(255, 245, 230, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(255, 107, 157, 0.34) !important;
+  box-shadow:0 14px 42px rgba(42, 16, 64, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(255, 107, 157, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(255, 107, 157, 0.55) !important;
+  box-shadow:0 8px 22px rgba(42, 16, 64, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFF5E6;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFF5E6;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 245, 230, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 245, 230, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 245, 230, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFF5E6 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFF5E6 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFF5E6 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFF5E6 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFF5E6;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 245, 230, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFF5E6;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 245, 230, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFF5E6;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 245, 230, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#FF6B9D; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(255, 107, 157, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(255, 179, 71, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 245, 230, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(255, 179, 71, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(255, 107, 157, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(42, 16, 64, 0.48), rgba(42, 16, 64, 0.8));
+  color:#FFF5E6;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(255, 107, 157, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #FF6B9D;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(255, 107, 157, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(255, 107, 157, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(255, 179, 71, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #FFB347;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(255, 179, 71, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(255, 179, 71, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 245, 230, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #FFF5E6;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(255, 245, 230, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 245, 230, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(255, 179, 71, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #FFB347;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(255, 179, 71, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(255, 179, 71, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(255, 107, 157, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #FF6B9D;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(255, 107, 157, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(255, 107, 157, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(42, 16, 64, 0.28), rgba(42, 16, 64, 0.72));
+  border-top:3px solid #2A1040;
+  color:#FFF5E6;
+  box-shadow:0 12px 28px rgba(42, 16, 64, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 245, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FF6B9D; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 245, 230, 0.16); color:#FFF5E6; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(42, 16, 64, 0.14); border:2px solid rgba(255, 245, 230, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/hongse-youhuo/theme.css
+++ b/skins-pro/hongse-youhuo/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(255, 45, 106, 0.32), rgba(255, 192, 212, 0.62));
+  --sp-sidebar-bg: rgba(255, 192, 212, 0.88);
+  --sp-sidebar-text: #FFC0D4;
+  --sp-sidebar-text-muted: rgba(255, 192, 212, 0.68);
+  --sp-sidebar-active-bg: rgba(255, 45, 106, 0.26);
+  --sp-sidebar-active-text: #FF2D6A;
+  --sp-text-primary: #FFC0D4;
+  --sp-text-main: #FFC0D4;
+  --sp-text-muted: rgba(255, 192, 212, 0.82);
+  --sp-text-muted-bright: rgba(255, 192, 212, 0.82);
+  --sp-text-muted-dim: rgba(255, 192, 212, 0.82);
+  --sp-text-stage:#FFC0D4;
+  --sp-text-stage-muted:rgba(255, 192, 212, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(255, 45, 106, 0.34) !important;
+  box-shadow:0 14px 42px rgba(255, 192, 212, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(255, 45, 106, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(255, 45, 106, 0.55) !important;
+  box-shadow:0 8px 22px rgba(255, 192, 212, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFC0D4;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFC0D4;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 192, 212, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 192, 212, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 192, 212, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFC0D4 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFC0D4 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFC0D4 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFC0D4 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFC0D4;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 192, 212, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFC0D4;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 192, 212, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFC0D4;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 192, 212, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#FF2D6A; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(255, 45, 106, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 192, 212, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(255, 45, 106, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(255, 192, 212, 0.48), rgba(255, 192, 212, 0.8));
+  color:#FFC0D4;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(255, 45, 106, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #FF2D6A;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(255, 45, 106, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(255, 45, 106, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #6c7f9e;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(108, 127, 158, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(108, 127, 158, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 192, 212, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #FFC0D4;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(255, 192, 212, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 192, 212, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #6c7f9e;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(108, 127, 158, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(108, 127, 158, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(255, 45, 106, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #FF2D6A;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(255, 45, 106, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(255, 45, 106, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(255, 192, 212, 0.28), rgba(255, 192, 212, 0.72));
+  border-top:3px solid #FFC0D4;
+  color:#FFC0D4;
+  box-shadow:0 12px 28px rgba(255, 192, 212, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 192, 212, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FF2D6A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 192, 212, 0.16); color:#FFC0D4; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(255, 192, 212, 0.14); border:2px solid rgba(255, 192, 212, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/honor-of-kings/theme.css
+++ b/skins-pro/honor-of-kings/theme.css
@@ -746,8 +746,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(231, 197, 106, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #F7E8BC;
+  --sp-sidebar-text-muted: rgba(247, 232, 188, 0.68);
+  --sp-sidebar-active-bg: rgba(231, 197, 106, 0.26);
+  --sp-sidebar-active-text: #E7C56A;
+  --sp-text-primary: #F7E8BC;
+  --sp-text-main: #F7E8BC;
+  --sp-text-muted: rgba(247, 232, 188, 0.82);
+  --sp-text-muted-bright: rgba(247, 232, 188, 0.82);
+  --sp-text-muted-dim: rgba(247, 232, 188, 0.82);
+  --sp-text-stage:#F7E8BC;
+  --sp-text-stage-muted:rgba(247, 232, 188, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(231, 197, 106, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(231, 197, 106, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(231, 197, 106, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F7E8BC;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F7E8BC;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(247, 232, 188, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(247, 232, 188, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(247, 232, 188, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F7E8BC !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F7E8BC !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F7E8BC !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F7E8BC !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F7E8BC;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(247, 232, 188, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F7E8BC;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(247, 232, 188, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F7E8BC;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(247, 232, 188, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#E7C56A; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(231, 197, 106, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(247, 232, 188, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(231, 197, 106, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F7E8BC;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(231, 197, 106, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #E7C56A;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(231, 197, 106, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(231, 197, 106, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(247, 232, 188, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F7E8BC;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(247, 232, 188, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(247, 232, 188, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(231, 197, 106, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #E7C56A;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(231, 197, 106, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(231, 197, 106, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#F7E8BC;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(247, 232, 188, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#E7C56A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(247, 232, 188, 0.16); color:#F7E8BC; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(247, 232, 188, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/ios-27-light/theme.css
+++ b/skins-pro/ios-27-light/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(0, 122, 255, 0.18), rgba(242, 242, 247, 0.08));
+  --sp-sidebar-bg: rgba(242, 242, 247, 0.84);
+  --sp-sidebar-text: #FFFFFF;
+  --sp-sidebar-text-muted: rgba(255, 255, 255, 0.78);
+  --sp-sidebar-active-bg: rgba(0, 122, 255, 0.22);
+  --sp-sidebar-active-text: #007AFF;
+  --sp-text-primary: #F2F2F7;
+  --sp-text-main: #F2F2F7;
+  --sp-text-muted: rgba(242, 242, 247, 0.72);
+  --sp-text-muted-bright: rgba(242, 242, 247, 0.72);
+  --sp-text-muted-dim: rgba(242, 242, 247, 0.72);
+  --sp-text-stage:#F2F2F7;
+  --sp-text-stage-muted:rgba(242, 242, 247, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(0, 122, 255, 0.34) !important;
+  box-shadow:0 14px 42px rgba(242, 242, 247, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(0, 122, 255, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(0, 122, 255, 0.55) !important;
+  box-shadow:0 8px 22px rgba(242, 242, 247, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFFFFF;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F2F2F7;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(242, 242, 247, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(242, 242, 247, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(242, 242, 247, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F2F2F7 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F2F2F7 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F2F2F7 !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F2F2F7 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFFFFF;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 255, 255, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F2F2F7;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(242, 242, 247, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F2F2F7;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(242, 242, 247, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C7C7CC; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(242, 242, 247, 0.52), rgba(242, 242, 247, 0.78));
+  color:#FFFFFF;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #007AFF;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(0, 122, 255, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #C7C7CC;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(199, 199, 204, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #FFFFFF;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(255, 255, 255, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 255, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #C7C7CC;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(199, 199, 204, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #007AFF;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(0, 122, 255, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(242, 242, 247, 0.24), rgba(242, 242, 247, 0.68));
+  border-top:3px solid #F2F2F7;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(242, 242, 247, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(242, 242, 247, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/iron-man/theme.css
+++ b/skins-pro/iron-man/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -629,8 +629,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(196, 30, 42, 0.32), rgba(10, 14, 20, 0.62));
+  --sp-sidebar-bg: rgba(10, 14, 20, 0.88);
+  --sp-sidebar-text: #FFE8E0;
+  --sp-sidebar-text-muted: rgba(255, 232, 224, 0.68);
+  --sp-sidebar-active-bg: rgba(196, 30, 42, 0.26);
+  --sp-sidebar-active-text: #C41E2A;
+  --sp-text-primary: #FFE8E0;
+  --sp-text-main: #FFE8E0;
+  --sp-text-muted: rgba(255, 232, 224, 0.82);
+  --sp-text-muted-bright: rgba(255, 232, 224, 0.82);
+  --sp-text-muted-dim: rgba(255, 232, 224, 0.82);
+  --sp-text-stage:#FFE8E0;
+  --sp-text-stage-muted:rgba(255, 232, 224, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(196, 30, 42, 0.34) !important;
+  box-shadow:0 14px 42px rgba(10, 14, 20, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(196, 30, 42, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(196, 30, 42, 0.55) !important;
+  box-shadow:0 8px 22px rgba(10, 14, 20, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFE8E0;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFE8E0;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 232, 224, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 232, 224, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 232, 224, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFE8E0 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFE8E0 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFE8E0 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFE8E0 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFE8E0;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 232, 224, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFE8E0;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 232, 224, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFE8E0;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 232, 224, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C41E2A; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(196, 30, 42, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 232, 224, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(196, 30, 42, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(10, 14, 20, 0.48), rgba(10, 14, 20, 0.8));
+  color:#FFE8E0;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(196, 30, 42, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #C41E2A;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(196, 30, 42, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(196, 30, 42, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #D4AF37;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(212, 175, 55, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(212, 175, 55, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 232, 224, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #FFE8E0;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(255, 232, 224, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 232, 224, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #D4AF37;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(212, 175, 55, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(212, 175, 55, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(196, 30, 42, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #C41E2A;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(196, 30, 42, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(196, 30, 42, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(10, 14, 20, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #0A0E14;
+  color:#FFE8E0;
+  box-shadow:0 12px 28px rgba(10, 14, 20, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 232, 224, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C41E2A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 232, 224, 0.16); color:#FFE8E0; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(10, 14, 20, 0.14); border:2px solid rgba(255, 232, 224, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/league-of-legends/theme.css
+++ b/skins-pro/league-of-legends/theme.css
@@ -212,7 +212,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -250,7 +250,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -704,8 +704,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(200, 170, 110, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #F0E6D2;
+  --sp-sidebar-text-muted: rgba(240, 230, 210, 0.68);
+  --sp-sidebar-active-bg: rgba(200, 170, 110, 0.26);
+  --sp-sidebar-active-text: #C8AA6E;
+  --sp-text-primary: #F0E6D2;
+  --sp-text-main: #F0E6D2;
+  --sp-text-muted: rgba(240, 230, 210, 0.82);
+  --sp-text-muted-bright: rgba(240, 230, 210, 0.82);
+  --sp-text-muted-dim: rgba(240, 230, 210, 0.82);
+  --sp-text-stage:#F0E6D2;
+  --sp-text-stage-muted:rgba(240, 230, 210, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(200, 170, 110, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(200, 170, 110, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(200, 170, 110, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F0E6D2;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F0E6D2;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(240, 230, 210, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(240, 230, 210, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(240, 230, 210, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F0E6D2 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F0E6D2 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F0E6D2 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F0E6D2 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F0E6D2;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(240, 230, 210, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F0E6D2;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(240, 230, 210, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F0E6D2;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(240, 230, 210, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C8AA6E; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(200, 170, 110, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(240, 230, 210, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(200, 170, 110, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F0E6D2;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(200, 170, 110, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C8AA6E;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(200, 170, 110, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(200, 170, 110, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(240, 230, 210, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F0E6D2;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(240, 230, 210, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(240, 230, 210, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(200, 170, 110, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C8AA6E;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(200, 170, 110, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(200, 170, 110, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#F0E6D2;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(240, 230, 210, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C8AA6E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(240, 230, 210, 0.16); color:#F0E6D2; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(240, 230, 210, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/legend-of-zelda/theme.css
+++ b/skins-pro/legend-of-zelda/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(46, 204, 113, 0.32), rgba(14, 21, 36, 0.62));
+  --sp-sidebar-bg: rgba(14, 21, 36, 0.88);
+  --sp-sidebar-text: #F5F0E6;
+  --sp-sidebar-text-muted: rgba(245, 240, 230, 0.68);
+  --sp-sidebar-active-bg: rgba(46, 204, 113, 0.26);
+  --sp-sidebar-active-text: #2ECC71;
+  --sp-text-primary: #F5F0E6;
+  --sp-text-main: #F5F0E6;
+  --sp-text-muted: rgba(245, 240, 230, 0.82);
+  --sp-text-muted-bright: rgba(245, 240, 230, 0.82);
+  --sp-text-muted-dim: rgba(245, 240, 230, 0.82);
+  --sp-text-stage:#F5F0E6;
+  --sp-text-stage-muted:rgba(245, 240, 230, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(46, 204, 113, 0.34) !important;
+  box-shadow:0 14px 42px rgba(14, 21, 36, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(46, 204, 113, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(46, 204, 113, 0.55) !important;
+  box-shadow:0 8px 22px rgba(14, 21, 36, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F5F0E6;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F5F0E6;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(245, 240, 230, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(245, 240, 230, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(245, 240, 230, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F5F0E6 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F5F0E6 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F5F0E6 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F5F0E6 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F5F0E6;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(245, 240, 230, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F5F0E6;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(245, 240, 230, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F5F0E6;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(245, 240, 230, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#2ECC71; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(46, 204, 113, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(245, 240, 230, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(46, 204, 113, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(14, 21, 36, 0.48), rgba(14, 21, 36, 0.8));
+  color:#F5F0E6;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(46, 204, 113, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #2ECC71;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(46, 204, 113, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(46, 204, 113, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #3498DB;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(245, 240, 230, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #F5F0E6;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(245, 240, 230, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(245, 240, 230, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #3498DB;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(46, 204, 113, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #2ECC71;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(46, 204, 113, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(46, 204, 113, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(14, 21, 36, 0.28), rgba(14, 21, 36, 0.72));
+  border-top:3px solid #0E1524;
+  color:#F5F0E6;
+  box-shadow:0 12px 28px rgba(14, 21, 36, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(245, 240, 230, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#2ECC71; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(245, 240, 230, 0.16); color:#F5F0E6; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(14, 21, 36, 0.14); border:2px solid rgba(245, 240, 230, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/maplestory/theme.css
+++ b/skins-pro/maplestory/theme.css
@@ -287,7 +287,7 @@ button { font:inherit; }
   border-radius:var(--sp-radius-glass);
   padding:var(--sp-space-lg);
   box-sizing:border-box;
-  background:var(--sp-glass-bg);
+  background:var(--sp-card-bg, var(--sp-glass-bg));
   backdrop-filter:blur(16px);
   -webkit-backdrop-filter:blur(16px);
   border:var(--sp-border-width) solid var(--sp-border-glass);
@@ -497,8 +497,214 @@ button { font:inherit; }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off { border-top:3px solid var(--sp-device-red); }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off { border-top:3px solid var(--sp-device-brown); }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(217, 151, 40, 0.18), rgba(11, 11, 11, 0.08));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.84);
+  --sp-sidebar-text: #1e2235;
+  --sp-sidebar-text-muted: rgba(30, 34, 53, 0.78);
+  --sp-sidebar-active-bg: rgba(217, 151, 40, 0.22);
+  --sp-sidebar-active-text: #D99728;
+  --sp-text-primary: #0B0B0B;
+  --sp-text-main: #0B0B0B;
+  --sp-text-muted: rgba(11, 11, 11, 0.72);
+  --sp-text-muted-bright: rgba(11, 11, 11, 0.72);
+  --sp-text-muted-dim: rgba(11, 11, 11, 0.72);
+  --sp-text-stage:#0B0B0B;
+  --sp-text-stage-muted:rgba(11, 11, 11, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(217, 151, 40, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(217, 151, 40, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(217, 151, 40, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#1e2235;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#0B0B0B;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(11, 11, 11, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(11, 11, 11, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(11, 11, 11, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#0B0B0B !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#0B0B0B !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#0B0B0B !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#0B0B0B !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#1e2235;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(30, 34, 53, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#0B0B0B;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(11, 11, 11, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#0B0B0B;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(11, 11, 11, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#7A5C2E; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(217, 151, 40, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(30, 34, 53, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(217, 151, 40, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(217, 151, 40, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #D99728;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(217, 151, 40, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(217, 151, 40, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #7A5C2E;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(30, 34, 53, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #1e2235;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(30, 34, 53, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(30, 34, 53, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #7A5C2E;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(217, 151, 40, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #D99728;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(217, 151, 40, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(217, 151, 40, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #0B0B0B;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/need-for-speed/theme.css
+++ b/skins-pro/need-for-speed/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(231, 76, 60, 0.32), rgba(10, 14, 20, 0.62));
+  --sp-sidebar-bg: rgba(10, 14, 20, 0.88);
+  --sp-sidebar-text: #F0F0F0;
+  --sp-sidebar-text-muted: rgba(240, 240, 240, 0.68);
+  --sp-sidebar-active-bg: rgba(231, 76, 60, 0.26);
+  --sp-sidebar-active-text: #E74C3C;
+  --sp-text-primary: #F0F0F0;
+  --sp-text-main: #F0F0F0;
+  --sp-text-muted: rgba(240, 240, 240, 0.82);
+  --sp-text-muted-bright: rgba(240, 240, 240, 0.82);
+  --sp-text-muted-dim: rgba(240, 240, 240, 0.82);
+  --sp-text-stage:#F0F0F0;
+  --sp-text-stage-muted:rgba(240, 240, 240, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(231, 76, 60, 0.34) !important;
+  box-shadow:0 14px 42px rgba(10, 14, 20, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(231, 76, 60, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(231, 76, 60, 0.55) !important;
+  box-shadow:0 8px 22px rgba(10, 14, 20, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F0F0F0;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F0F0F0;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(240, 240, 240, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(240, 240, 240, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(240, 240, 240, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F0F0F0 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F0F0F0 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F0F0F0 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F0F0F0 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F0F0F0;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(240, 240, 240, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F0F0F0;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(240, 240, 240, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F0F0F0;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(240, 240, 240, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#E74C3C; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(240, 240, 240, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(10, 14, 20, 0.48), rgba(10, 14, 20, 0.8));
+  color:#F0F0F0;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #E74C3C;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(231, 76, 60, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(231, 76, 60, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #3498DB;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(240, 240, 240, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #F0F0F0;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(240, 240, 240, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(240, 240, 240, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #3498DB;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #E74C3C;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(231, 76, 60, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(231, 76, 60, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(10, 14, 20, 0.28), rgba(10, 14, 20, 0.72));
+  border-top:3px solid #0A0E14;
+  color:#F0F0F0;
+  box-shadow:0 12px 28px rgba(10, 14, 20, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(240, 240, 240, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(240, 240, 240, 0.16); color:#F0F0F0; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(10, 14, 20, 0.14); border:2px solid rgba(240, 240, 240, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

happy-match, hongse-youhuo, honor-of-kings, ios-27-light, iron-man, league-of-legends, legend-of-zelda, maplestory, need-for-speed

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [x] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [x] |

### 架构影响确认 / Architecture Impact

- [ ] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [x] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Batch 3/6 of the card text readability fix. Inject `skins-pro card theme port` into `theme.css` for 9 skins so muted labels and glass-card text stay legible.

Split from #40 because the combined diff exceeded Sourcery's 150k review limit.

### 附加信息 / Additional Info

Part of split series: fix/card-text-readability-1 .. fix/card-text-readability-6. Supersedes #40.