### PR TITLE
fix(skins): improve card text readability (batch 4/6)

### DIFF
--- a/skins-pro/oil-painting-classic/theme.css
+++ b/skins-pro/oil-painting-classic/theme.css
@@ -4,7 +4,7 @@
   --sp-sidebar-width:200px; --sp-app-padding:16px; --sp-stage-radius:24px;
   --sp-runtime-height:560px; --sp-runtime-min-height:560px;
   --sp-glass-bg: rgba(255, 255, 255, 0.78); --sp-panel-bg: rgba(255, 255, 255, 0.92);
-  --sp-base-texture: url("./background.png"); --sp-stage-texture: url("./background.png");
+  --sp-base-texture: url("./background.jpg"); --sp-stage-texture: url("./background.jpg");
   --sp-app-overlay:linear-gradient(135deg,rgba(12,15,24,.78),rgba(20,24,36,.76),rgba(15,19,30,.78));
   --sp-stage-overlay:none;
   --sp-room-overlay:linear-gradient(180deg,transparent 40%,rgba(0,0,0,.45));
@@ -255,9 +255,14 @@ button { font:inherit; }
   --sp-card-bg: linear-gradient(145deg, rgba(201, 162, 39, 0.18), rgba(26, 20, 16, 0.08));
   --sp-sidebar-bg: rgba(26, 20, 16, 0.84);
   --sp-sidebar-text: #F4E8D0;
-  --sp-sidebar-text-muted: rgba(244, 232, 208, 0.72);
+  --sp-sidebar-text-muted: rgba(244, 232, 208, 0.78);
   --sp-sidebar-active-bg: rgba(201, 162, 39, 0.22);
   --sp-sidebar-active-text: #C9A227;
+  --sp-text-primary: #1A1410;
+  --sp-text-main: #1A1410;
+  --sp-text-muted: rgba(26, 20, 16, 0.72);
+  --sp-text-muted-bright: rgba(26, 20, 16, 0.72);
+  --sp-text-muted-dim: rgba(26, 20, 16, 0.72);
   --sp-text-stage:#1A1410;
   --sp-text-stage-muted:rgba(26, 20, 16, 0.58);
 }
@@ -304,27 +309,54 @@ button { font:inherit; }
   background:var(--sp-card-bg, var(--sp-glass-bg));
   color:#1A1410;
 }
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(26, 20, 16, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(26, 20, 16, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(26, 20, 16, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#1A1410 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#1A1410 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#1A1410 !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#1A1410 !important;
+  font-weight:700;
+}
 .device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
   color:#F4E8D0;
-  text-shadow:0 1px 4px rgba(255,255,255,.75);
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
 }
-.device .muted, .camera-card .muted { color:rgba(244, 232, 208, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.device .muted, .camera-card .muted { color:rgba(244, 232, 208, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .device .status, .device .count-tag { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
   color:#1A1410;
-  text-shadow:0 1px 4px rgba(255,255,255,.85),0 2px 12px rgba(255,255,255,.55);
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
   font-weight:700;
 }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
   color:rgba(26, 20, 16, 0.58);
   font-weight:600;
-  text-shadow:0 1px 4px rgba(255,255,255,.75);
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
 }
-.env-value,.energy-value,.maintenance-value,.time-main,.time-sub,.maintenance-item,.section-title h2,.section-title .muted,.panel-scenes .scene,.scene,.chip {
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
   color:#1A1410;
+  font-weight:700;
 }
-.time-sub,.maintenance-item,.section-title .muted,.scene .muted,.energy-value small,.energy-footer,.down {
+.time-sub,.energy-value small,.energy-footer,.down {
   color:rgba(26, 20, 16, 0.72);
+  font-weight:600;
 }
 .env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
 .energy-value { color:#5C4033; }
@@ -367,7 +399,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(201, 162, 39, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(201, 162, 39, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 
@@ -378,7 +410,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(92, 64, 51, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(92, 64, 51, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 
@@ -389,7 +421,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(244, 232, 208, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(244, 232, 208, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 
@@ -400,7 +432,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(92, 64, 51, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(92, 64, 51, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 
@@ -411,7 +443,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(201, 162, 39, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(201, 162, 39, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 
@@ -422,7 +454,7 @@ button { font:inherit; }
   box-shadow:0 12px 28px rgba(26, 20, 16, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(244, 232, 208, 0.84); }
-.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.75); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#F4E8D0; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(26, 20, 16, 0.14); color:#F4E8D0; }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 20, 16, 0.16); border:2px solid rgba(26, 20, 16, 0.18); }
 /* end skins-pro card theme port */

--- a/skins-pro/peacekeeper-elite/theme.css
+++ b/skins-pro/peacekeeper-elite/theme.css
@@ -212,7 +212,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -250,7 +250,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -704,8 +704,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(245, 166, 35, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #E8EDDF;
+  --sp-sidebar-text-muted: rgba(232, 237, 223, 0.68);
+  --sp-sidebar-active-bg: rgba(245, 166, 35, 0.26);
+  --sp-sidebar-active-text: #F5A623;
+  --sp-text-primary: #E8EDDF;
+  --sp-text-main: #E8EDDF;
+  --sp-text-muted: rgba(232, 237, 223, 0.82);
+  --sp-text-muted-bright: rgba(232, 237, 223, 0.82);
+  --sp-text-muted-dim: rgba(232, 237, 223, 0.82);
+  --sp-text-stage:#E8EDDF;
+  --sp-text-stage-muted:rgba(232, 237, 223, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(245, 166, 35, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(245, 166, 35, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(245, 166, 35, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#E8EDDF;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#E8EDDF;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(232, 237, 223, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(232, 237, 223, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(232, 237, 223, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#E8EDDF !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#E8EDDF !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#E8EDDF !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#E8EDDF !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#E8EDDF;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(232, 237, 223, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#E8EDDF;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(232, 237, 223, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#E8EDDF;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(232, 237, 223, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#F5A623; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(245, 166, 35, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(232, 237, 223, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(245, 166, 35, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8EDDF;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(245, 166, 35, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F5A623;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(245, 166, 35, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(245, 166, 35, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(232, 237, 223, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #E8EDDF;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(232, 237, 223, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(232, 237, 223, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(245, 166, 35, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F5A623;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(245, 166, 35, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(245, 166, 35, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#E8EDDF;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(232, 237, 223, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#F5A623; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(232, 237, 223, 0.16); color:#E8EDDF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(232, 237, 223, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/plants-vs-zombies/theme.css
+++ b/skins-pro/plants-vs-zombies/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(127, 212, 52, 0.32), rgba(26, 40, 16, 0.62));
+  --sp-sidebar-bg: rgba(26, 40, 16, 0.88);
+  --sp-sidebar-text: #F5FFE8;
+  --sp-sidebar-text-muted: rgba(245, 255, 232, 0.68);
+  --sp-sidebar-active-bg: rgba(127, 212, 52, 0.26);
+  --sp-sidebar-active-text: #7FD434;
+  --sp-text-primary: #F5FFE8;
+  --sp-text-main: #F5FFE8;
+  --sp-text-muted: rgba(245, 255, 232, 0.82);
+  --sp-text-muted-bright: rgba(245, 255, 232, 0.82);
+  --sp-text-muted-dim: rgba(245, 255, 232, 0.82);
+  --sp-text-stage:#F5FFE8;
+  --sp-text-stage-muted:rgba(245, 255, 232, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(127, 212, 52, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 40, 16, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(127, 212, 52, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(127, 212, 52, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 40, 16, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F5FFE8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F5FFE8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(245, 255, 232, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(245, 255, 232, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(245, 255, 232, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F5FFE8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F5FFE8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F5FFE8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F5FFE8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F5FFE8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(245, 255, 232, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F5FFE8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(245, 255, 232, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F5FFE8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(245, 255, 232, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#7FD434; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(127, 212, 52, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(139, 69, 19, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(245, 255, 232, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(139, 69, 19, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(127, 212, 52, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 40, 16, 0.48), rgba(26, 40, 16, 0.8));
+  color:#F5FFE8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(127, 212, 52, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #7FD434;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(127, 212, 52, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(127, 212, 52, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(139, 69, 19, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #8B4513;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(139, 69, 19, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(139, 69, 19, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(245, 255, 232, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #F5FFE8;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(245, 255, 232, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(245, 255, 232, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(139, 69, 19, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #8B4513;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(139, 69, 19, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(139, 69, 19, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(127, 212, 52, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #7FD434;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(127, 212, 52, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(127, 212, 52, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 40, 16, 0.28), rgba(26, 40, 16, 0.72));
+  border-top:3px solid #1A2810;
+  color:#F5FFE8;
+  box-shadow:0 12px 28px rgba(26, 40, 16, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(245, 255, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#7FD434; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(245, 255, 232, 0.16); color:#F5FFE8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 40, 16, 0.14); border:2px solid rgba(245, 255, 232, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/pocket-monsters/theme.css
+++ b/skins-pro/pocket-monsters/theme.css
@@ -131,7 +131,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -169,7 +169,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -277,7 +277,7 @@ button { font:inherit; }
 .sp-add { min-height:36px; border:var(--sp-border-width) dashed var(--sp-border-muted); border-radius:var(--sp-radius-sm); background:transparent; color:var(--sp-accent); cursor:pointer; font:inherit; font-size:var(--sp-font-lg); margin-top:var(--sp-space-xs); transition:background .2s; }
 .sp-add:hover { background:var(--sp-accent-alpha); }
 
-.sidebar,.glass-card,.time-card { background:var(--sp-glass-bg); border-color:var(--sp-border-glass); }
+.sidebar,.glass-card,.time-card { background:var(--sp-card-bg, var(--sp-glass-bg)); border-color:var(--sp-border-glass); }
 .device-unavailable { background:rgba(200,200,210,.80); color:#1A1A2E; }
 .devices .device,.devices-page-grid .device { border:var(--sp-border-width) solid var(--sp-border-glass); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); }
 .bottom-devices .section-title h2,.bottom-devices .section-title .muted { color:var(--sp-text-stage,var(--sp-text-main)); text-shadow:0 1px 6px rgba(255,255,255,.75),0 2px 12px rgba(0,0,0,.18); }
@@ -485,8 +485,214 @@ button { font:inherit; }
   backdrop-filter:blur(28px) saturate(200%);
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(227, 53, 13, 0.18), rgba(26, 26, 46, 0.08));
+  --sp-sidebar-bg: rgba(26, 26, 46, 0.84);
+  --sp-sidebar-text: #FFF8E8;
+  --sp-sidebar-text-muted: rgba(255, 248, 232, 0.78);
+  --sp-sidebar-active-bg: rgba(227, 53, 13, 0.22);
+  --sp-sidebar-active-text: #E3350D;
+  --sp-text-primary: #1A1A2E;
+  --sp-text-main: #1A1A2E;
+  --sp-text-muted: rgba(26, 26, 46, 0.72);
+  --sp-text-muted-bright: rgba(26, 26, 46, 0.72);
+  --sp-text-muted-dim: rgba(26, 26, 46, 0.72);
+  --sp-text-stage:#1A1A2E;
+  --sp-text-stage-muted:rgba(26, 26, 46, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(227, 53, 13, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 26, 46, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(227, 53, 13, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(227, 53, 13, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 26, 46, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFF8E8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#1A1A2E;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(26, 26, 46, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(26, 26, 46, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(26, 26, 46, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#1A1A2E !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#1A1A2E !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#1A1A2E !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#1A1A2E !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFF8E8;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 248, 232, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#1A1A2E;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(26, 26, 46, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#1A1A2E;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(26, 26, 46, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#3B4CCA; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(227, 53, 13, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(59, 76, 202, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(59, 76, 202, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(227, 53, 13, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 26, 46, 0.52), rgba(26, 26, 46, 0.78));
+  color:#FFF8E8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(227, 53, 13, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #E3350D;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(227, 53, 13, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(227, 53, 13, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(59, 76, 202, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #3B4CCA;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(59, 76, 202, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(59, 76, 202, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #FFF8E8;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(255, 248, 232, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 232, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(59, 76, 202, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #3B4CCA;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(59, 76, 202, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(59, 76, 202, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(227, 53, 13, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #E3350D;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(227, 53, 13, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(227, 53, 13, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 26, 46, 0.24), rgba(26, 26, 46, 0.68));
+  border-top:3px solid #1A1A2E;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(26, 26, 46, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 248, 232, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FFF8E8; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(26, 26, 46, 0.14); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 26, 46, 0.16); border:2px solid rgba(26, 26, 46, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/quiet-luxury/theme.css
+++ b/skins-pro/quiet-luxury/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(127, 114, 101, 0.32), rgba(246, 246, 243, 0.62));
+  --sp-sidebar-bg: rgba(246, 246, 243, 0.88);
+  --sp-sidebar-text: #F6F6F3;
+  --sp-sidebar-text-muted: rgba(246, 246, 243, 0.68);
+  --sp-sidebar-active-bg: rgba(127, 114, 101, 0.26);
+  --sp-sidebar-active-text: #7F7265;
+  --sp-text-primary: #F6F6F3;
+  --sp-text-main: #F6F6F3;
+  --sp-text-muted: rgba(246, 246, 243, 0.82);
+  --sp-text-muted-bright: rgba(246, 246, 243, 0.82);
+  --sp-text-muted-dim: rgba(246, 246, 243, 0.82);
+  --sp-text-stage:#F6F6F3;
+  --sp-text-stage-muted:rgba(246, 246, 243, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(127, 114, 101, 0.34) !important;
+  box-shadow:0 14px 42px rgba(246, 246, 243, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(127, 114, 101, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(127, 114, 101, 0.55) !important;
+  box-shadow:0 8px 22px rgba(246, 246, 243, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F6F6F3;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F6F6F3;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(246, 246, 243, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(246, 246, 243, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(246, 246, 243, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F6F6F3 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F6F6F3 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F6F6F3 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F6F6F3 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F6F6F3;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(246, 246, 243, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F6F6F3;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(246, 246, 243, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F6F6F3;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(246, 246, 243, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#7F7265; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(127, 114, 101, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(246, 246, 243, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(127, 114, 101, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(246, 246, 243, 0.48), rgba(246, 246, 243, 0.8));
+  color:#F6F6F3;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(127, 114, 101, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #7F7265;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(127, 114, 101, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(127, 114, 101, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #6c7f9e;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(108, 127, 158, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(108, 127, 158, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(246, 246, 243, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #F6F6F3;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(246, 246, 243, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(246, 246, 243, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(108, 127, 158, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #6c7f9e;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(108, 127, 158, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(108, 127, 158, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(127, 114, 101, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #7F7265;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(127, 114, 101, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(127, 114, 101, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(246, 246, 243, 0.28), rgba(246, 246, 243, 0.72));
+  border-top:3px solid #F6F6F3;
+  color:#F6F6F3;
+  box-shadow:0 12px 28px rgba(246, 246, 243, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(246, 246, 243, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#7F7265; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(246, 246, 243, 0.16); color:#F6F6F3; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(246, 246, 243, 0.14); border:2px solid rgba(246, 246, 243, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/red-dead-redemption-2/theme.css
+++ b/skins-pro/red-dead-redemption-2/theme.css
@@ -212,7 +212,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -250,7 +250,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -704,8 +704,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(196, 92, 46, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #F2E0C4;
+  --sp-sidebar-text-muted: rgba(242, 224, 196, 0.68);
+  --sp-sidebar-active-bg: rgba(196, 92, 46, 0.26);
+  --sp-sidebar-active-text: #C45C2E;
+  --sp-text-primary: #F2E0C4;
+  --sp-text-main: #F2E0C4;
+  --sp-text-muted: rgba(242, 224, 196, 0.82);
+  --sp-text-muted-bright: rgba(242, 224, 196, 0.82);
+  --sp-text-muted-dim: rgba(242, 224, 196, 0.82);
+  --sp-text-stage:#F2E0C4;
+  --sp-text-stage-muted:rgba(242, 224, 196, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(196, 92, 46, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(196, 92, 46, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(196, 92, 46, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F2E0C4;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F2E0C4;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(242, 224, 196, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(242, 224, 196, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(242, 224, 196, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F2E0C4 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F2E0C4 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F2E0C4 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F2E0C4 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F2E0C4;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(242, 224, 196, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F2E0C4;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(242, 224, 196, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F2E0C4;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(242, 224, 196, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C45C2E; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(196, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(242, 224, 196, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(196, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E0C4;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(196, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C45C2E;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(196, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(196, 92, 46, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(242, 224, 196, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F2E0C4;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(242, 224, 196, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(242, 224, 196, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(196, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C45C2E;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(196, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(196, 92, 46, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#F2E0C4;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(242, 224, 196, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C45C2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(242, 224, 196, 0.16); color:#F2E0C4; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(242, 224, 196, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/red-smart-home/theme.css
+++ b/skins-pro/red-smart-home/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -280,8 +280,214 @@ button { font:inherit; }
 .weather-row {
   background: color-mix(in srgb, #FFF8F0 90%, #fff);
 }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(193, 39, 45, 0.18), rgba(92, 16, 24, 0.08));
+  --sp-sidebar-bg: rgba(92, 16, 24, 0.84);
+  --sp-sidebar-text: #5C1018;
+  --sp-sidebar-text-muted: rgba(212, 168, 75, 0.72);
+  --sp-sidebar-active-bg: rgba(193, 39, 45, 0.22);
+  --sp-sidebar-active-text: #C1272D;
+  --sp-text-primary: #5C1018;
+  --sp-text-main: #5C1018;
+  --sp-text-muted: rgba(92, 16, 24, 0.72);
+  --sp-text-muted-bright: rgba(92, 16, 24, 0.72);
+  --sp-text-muted-dim: rgba(92, 16, 24, 0.72);
+  --sp-text-stage:#5C1018;
+  --sp-text-stage-muted:rgba(92, 16, 24, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(193, 39, 45, 0.34) !important;
+  box-shadow:0 14px 42px rgba(92, 16, 24, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(193, 39, 45, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(193, 39, 45, 0.55) !important;
+  box-shadow:0 8px 22px rgba(92, 16, 24, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#D4A84B;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#5C1018;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(92, 16, 24, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(92, 16, 24, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(92, 16, 24, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#5C1018 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#5C1018 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#5C1018 !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#5C1018 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#D4A84B;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(212, 168, 75, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#5C1018;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(92, 16, 24, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#5C1018;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(92, 16, 24, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#FFF8F0; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(193, 39, 45, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(255, 248, 240, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(212, 168, 75, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(255, 248, 240, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(193, 39, 45, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(92, 16, 24, 0.52), rgba(92, 16, 24, 0.78));
+  color:#D4A84B;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(193, 39, 45, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #C1272D;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(193, 39, 45, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(193, 39, 45, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 240, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #FFF8F0;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(255, 248, 240, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 240, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(212, 168, 75, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #D4A84B;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(212, 168, 75, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(212, 168, 75, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 240, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #FFF8F0;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(255, 248, 240, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 240, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(193, 39, 45, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #C1272D;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(193, 39, 45, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(193, 39, 45, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(92, 16, 24, 0.24), rgba(92, 16, 24, 0.68));
+  border-top:3px solid #5C1018;
+  color:#D4A84B;
+  box-shadow:0 12px 28px rgba(92, 16, 24, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(212, 168, 75, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#D4A84B; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(92, 16, 24, 0.14); color:#D4A84B; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(92, 16, 24, 0.16); border:2px solid rgba(92, 16, 24, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/resident-evil/theme.css
+++ b/skins-pro/resident-evil/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(196, 30, 58, 0.32), rgba(10, 14, 12, 0.62));
+  --sp-sidebar-bg: rgba(10, 14, 12, 0.88);
+  --sp-sidebar-text: #E8DCC8;
+  --sp-sidebar-text-muted: rgba(232, 220, 200, 0.68);
+  --sp-sidebar-active-bg: rgba(196, 30, 58, 0.26);
+  --sp-sidebar-active-text: #C41E3A;
+  --sp-text-primary: #E8DCC8;
+  --sp-text-main: #E8DCC8;
+  --sp-text-muted: rgba(232, 220, 200, 0.82);
+  --sp-text-muted-bright: rgba(232, 220, 200, 0.82);
+  --sp-text-muted-dim: rgba(232, 220, 200, 0.82);
+  --sp-text-stage:#E8DCC8;
+  --sp-text-stage-muted:rgba(232, 220, 200, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(196, 30, 58, 0.34) !important;
+  box-shadow:0 14px 42px rgba(10, 14, 12, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(196, 30, 58, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(196, 30, 58, 0.55) !important;
+  box-shadow:0 8px 22px rgba(10, 14, 12, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#E8DCC8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#E8DCC8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(232, 220, 200, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(232, 220, 200, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(232, 220, 200, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#E8DCC8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#E8DCC8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#E8DCC8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#E8DCC8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#E8DCC8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(232, 220, 200, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#E8DCC8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(232, 220, 200, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#E8DCC8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(232, 220, 200, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C41E3A; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(196, 30, 58, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(45, 90, 61, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(232, 220, 200, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(45, 90, 61, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(196, 30, 58, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(10, 14, 12, 0.48), rgba(10, 14, 12, 0.8));
+  color:#E8DCC8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(196, 30, 58, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #C41E3A;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(196, 30, 58, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(196, 30, 58, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(45, 90, 61, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #2D5A3D;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(45, 90, 61, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(45, 90, 61, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(232, 220, 200, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #E8DCC8;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(232, 220, 200, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(232, 220, 200, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(45, 90, 61, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #2D5A3D;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(45, 90, 61, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(45, 90, 61, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(196, 30, 58, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #C41E3A;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(196, 30, 58, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(196, 30, 58, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(10, 14, 12, 0.28), rgba(10, 14, 12, 0.72));
+  border-top:3px solid #0A0E0C;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(10, 14, 12, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C41E3A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(10, 14, 12, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

oil-painting-classic, peacekeeper-elite, plants-vs-zombies, pocket-monsters, quiet-luxury, red-dead-redemption-2, red-smart-home, resident-evil

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [x] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [x] |

### 架构影响确认 / Architecture Impact

- [ ] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [x] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Batch 4/6 of the card text readability fix. Inject `skins-pro card theme port` into `theme.css` for 8 skins so muted labels and glass-card text stay legible.

Split from #40 because the combined diff exceeded Sourcery's 150k review limit.

### 附加信息 / Additional Info

Part of split series: fix/card-text-readability-1 .. fix/card-text-readability-6. Supersedes #40.

## Summary by Sourcery

Improve card text readability and themed card surfaces across multiple skins.

New Features:
- Introduce card-specific theming variables and styles for device, glass, and camera cards in eight skins to keep labels and text legible on textured or glass backgrounds.

Enhancements:
- Wire existing layouts to the new card background variable so card surfaces participate in per-skin theming without changing structure.
- Tune colors, shadows, and muted text styling in several skins to increase contrast and readability for headings, chips, and status text.
- Update the oil-painting-classic skin background asset and text color palette for better visual coherence with the new card theming.