### PR TITLE
fix(skins): improve card text readability (batch 5/6)

### DIFF
--- a/skins-pro/retro-luxury/theme.css
+++ b/skins-pro/retro-luxury/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(127, 212, 160, 0.32), rgba(8, 20, 16, 0.62));
+  --sp-sidebar-bg: rgba(8, 20, 16, 0.88);
+  --sp-sidebar-text: #E9FFF2;
+  --sp-sidebar-text-muted: rgba(233, 255, 242, 0.68);
+  --sp-sidebar-active-bg: rgba(127, 212, 160, 0.26);
+  --sp-sidebar-active-text: #7FD4A0;
+  --sp-text-primary: #E9FFF2;
+  --sp-text-main: #E9FFF2;
+  --sp-text-muted: rgba(233, 255, 242, 0.82);
+  --sp-text-muted-bright: rgba(233, 255, 242, 0.82);
+  --sp-text-muted-dim: rgba(233, 255, 242, 0.82);
+  --sp-text-stage:#E9FFF2;
+  --sp-text-stage-muted:rgba(233, 255, 242, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(127, 212, 160, 0.34) !important;
+  box-shadow:0 14px 42px rgba(8, 20, 16, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(127, 212, 160, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(127, 212, 160, 0.55) !important;
+  box-shadow:0 8px 22px rgba(8, 20, 16, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#E9FFF2;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#E9FFF2;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(233, 255, 242, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(233, 255, 242, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(233, 255, 242, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#E9FFF2 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#E9FFF2 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#E9FFF2 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#E9FFF2 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#E9FFF2;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(233, 255, 242, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#E9FFF2;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(233, 255, 242, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#E9FFF2;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(233, 255, 242, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#7FD4A0; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(127, 212, 160, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(46, 107, 74, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(233, 255, 242, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(46, 107, 74, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(127, 212, 160, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(8, 20, 16, 0.48), rgba(8, 20, 16, 0.8));
+  color:#E9FFF2;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(127, 212, 160, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #7FD4A0;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(127, 212, 160, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(127, 212, 160, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(46, 107, 74, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #2E6B4A;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(46, 107, 74, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(46, 107, 74, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(233, 255, 242, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #E9FFF2;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(233, 255, 242, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(233, 255, 242, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(46, 107, 74, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #2E6B4A;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(46, 107, 74, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(46, 107, 74, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(127, 212, 160, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #7FD4A0;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(127, 212, 160, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(127, 212, 160, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(8, 20, 16, 0.28), rgba(8, 20, 16, 0.72));
+  border-top:3px solid #081410;
+  color:#E9FFF2;
+  box-shadow:0 12px 28px rgba(8, 20, 16, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(233, 255, 242, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#7FD4A0; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(233, 255, 242, 0.16); color:#E9FFF2; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(8, 20, 16, 0.14); border:2px solid rgba(233, 255, 242, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/romance-three-kingdoms/theme.css
+++ b/skins-pro/romance-three-kingdoms/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(194, 58, 46, 0.32), rgba(26, 14, 8, 0.62));
+  --sp-sidebar-bg: rgba(26, 14, 8, 0.88);
+  --sp-sidebar-text: #F2E6C9;
+  --sp-sidebar-text-muted: rgba(242, 230, 201, 0.68);
+  --sp-sidebar-active-bg: rgba(194, 58, 46, 0.26);
+  --sp-sidebar-active-text: #C23A2E;
+  --sp-text-primary: #F2E6C9;
+  --sp-text-main: #F2E6C9;
+  --sp-text-muted: rgba(242, 230, 201, 0.82);
+  --sp-text-muted-bright: rgba(242, 230, 201, 0.82);
+  --sp-text-muted-dim: rgba(242, 230, 201, 0.82);
+  --sp-text-stage:#F2E6C9;
+  --sp-text-stage-muted:rgba(242, 230, 201, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(194, 58, 46, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 14, 8, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(194, 58, 46, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(194, 58, 46, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 14, 8, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F2E6C9;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F2E6C9;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(242, 230, 201, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(242, 230, 201, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(242, 230, 201, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F2E6C9 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F2E6C9 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F2E6C9 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F2E6C9 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F2E6C9;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(242, 230, 201, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F2E6C9;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(242, 230, 201, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F2E6C9;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(242, 230, 201, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C23A2E; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(194, 58, 46, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(139, 105, 20, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(242, 230, 201, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(139, 105, 20, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(194, 58, 46, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 14, 8, 0.48), rgba(26, 14, 8, 0.8));
+  color:#F2E6C9;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(194, 58, 46, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #C23A2E;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(194, 58, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(194, 58, 46, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(139, 105, 20, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #8B6914;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(139, 105, 20, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(139, 105, 20, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(242, 230, 201, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #F2E6C9;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(242, 230, 201, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(242, 230, 201, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(139, 105, 20, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #8B6914;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(139, 105, 20, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(139, 105, 20, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(194, 58, 46, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #C23A2E;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(194, 58, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(194, 58, 46, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 14, 8, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #1A0E08;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(26, 14, 8, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C23A2E; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 14, 8, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/smarto-minimal/theme.css
+++ b/skins-pro/smarto-minimal/theme.css
@@ -147,7 +147,7 @@ button { font:inherit; }
 .security-grid { display:flex; flex-direction:column; gap:var(--sp-space-sm); }
 .security-cameras { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
 .security-devices { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:3/2; background:var(--sp-camera-bg); min-height:100px; }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content auto auto; gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 
@@ -477,7 +477,7 @@ button { font:inherit; }
 .sp-add { min-height:36px; border:var(--sp-border-width) dashed var(--sp-border-muted); border-radius:var(--sp-radius-sm); background:transparent; color:var(--sp-accent); cursor:pointer; font:inherit; font-size:var(--sp-font-lg); margin-top:var(--sp-space-xs); transition:background .2s; }
 .sp-add:hover { background:var(--sp-accent-alpha); }
 
-.sidebar,.glass-card,.time-card { background:var(--sp-glass-bg); border-color:var(--sp-border-glass); }
+.sidebar,.glass-card,.time-card { background:var(--sp-card-bg, var(--sp-glass-bg)); border-color:var(--sp-border-glass); }
 .device-unavailable { background:rgba(200,200,210,.80); color:#2C2C2E; }
 .devices .device,.devices-page-grid .device { border:var(--sp-border-width) solid var(--sp-border-glass); backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); }
 .bottom-devices .section-title h2,.bottom-devices .section-title .muted { color:var(--sp-text-stage,var(--sp-text-main)); text-shadow:0 1px 6px rgba(255,255,255,.75),0 2px 12px rgba(0,0,0,.18); }
@@ -997,4 +997,213 @@ button { font:inherit; }
     max-width: 90px;
   }
 }
+
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(28, 28, 30, 0.18), rgba(44, 44, 46, 0.08));
+  --sp-sidebar-bg: rgba(44, 44, 46, 0.84);
+  --sp-sidebar-text: #FFFFFF;
+  --sp-sidebar-text-muted: rgba(255, 255, 255, 0.78);
+  --sp-sidebar-active-bg: rgba(28, 28, 30, 0.22);
+  --sp-sidebar-active-text: #1C1C1E;
+  --sp-text-primary: #2C2C2E;
+  --sp-text-main: #2C2C2E;
+  --sp-text-muted: rgba(44, 44, 46, 0.72);
+  --sp-text-muted-bright: rgba(44, 44, 46, 0.72);
+  --sp-text-muted-dim: rgba(44, 44, 46, 0.72);
+  --sp-text-stage:#2C2C2E;
+  --sp-text-stage-muted:rgba(44, 44, 46, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(28, 28, 30, 0.34) !important;
+  box-shadow:0 14px 42px rgba(44, 44, 46, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(28, 28, 30, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(28, 28, 30, 0.55) !important;
+  box-shadow:0 8px 22px rgba(44, 44, 46, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFFFFF;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#2C2C2E;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(44, 44, 46, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(44, 44, 46, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(44, 44, 46, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#2C2C2E !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#2C2C2E !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#2C2C2E !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#2C2C2E !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFFFFF;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 255, 255, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#2C2C2E;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(44, 44, 46, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#2C2C2E;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(44, 44, 46, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#8E8E93; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
+
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-green {
+  background:linear-gradient(165deg, rgba(142, 142, 147, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(142, 142, 147, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(44, 44, 46, 0.52), rgba(44, 44, 46, 0.78));
+  color:#FFFFFF;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #1C1C1E;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(28, 28, 30, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(28, 28, 30, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(142, 142, 147, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #8E8E93;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(142, 142, 147, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(142, 142, 147, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #FFFFFF;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(255, 255, 255, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 255, 255, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(142, 142, 147, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #8E8E93;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(142, 142, 147, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(142, 142, 147, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #1C1C1E;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(28, 28, 30, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(28, 28, 30, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(44, 44, 46, 0.24), rgba(44, 44, 46, 0.68));
+  border-top:3px solid #2C2C2E;
+  color:#FFFFFF;
+  box-shadow:0 12px 28px rgba(44, 44, 46, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 255, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(44, 44, 46, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(44, 44, 46, 0.16); border:2px solid rgba(44, 44, 46, 0.18); }
+/* end skins-pro card theme port */
 

--- a/skins-pro/soft-home/theme.css
+++ b/skins-pro/soft-home/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   background: var(--sp-panel-bg);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(184, 154, 116, 0.18), rgba(44, 44, 44, 0.08));
+  --sp-sidebar-bg: rgba(44, 44, 44, 0.84);
+  --sp-sidebar-text: #A6C8FF;
+  --sp-sidebar-text-muted: rgba(166, 200, 255, 0.78);
+  --sp-sidebar-active-bg: rgba(184, 154, 116, 0.22);
+  --sp-sidebar-active-text: #B89A74;
+  --sp-text-primary: #2C2C2C;
+  --sp-text-main: #2C2C2C;
+  --sp-text-muted: rgba(44, 44, 44, 0.72);
+  --sp-text-muted-bright: rgba(44, 44, 44, 0.72);
+  --sp-text-muted-dim: rgba(44, 44, 44, 0.72);
+  --sp-text-stage:#2C2C2C;
+  --sp-text-stage-muted:rgba(44, 44, 44, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(184, 154, 116, 0.34) !important;
+  box-shadow:0 14px 42px rgba(44, 44, 44, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(184, 154, 116, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(184, 154, 116, 0.55) !important;
+  box-shadow:0 8px 22px rgba(44, 44, 44, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#A6C8FF;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#2C2C2C;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(44, 44, 44, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(44, 44, 44, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(44, 44, 44, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#2C2C2C !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#2C2C2C !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#2C2C2C !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#2C2C2C !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#A6C8FF;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(166, 200, 255, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#2C2C2C;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(44, 44, 44, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#2C2C2C;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(44, 44, 44, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#F5F7F8; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(184, 154, 116, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(245, 247, 248, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(166, 200, 255, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(245, 247, 248, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(184, 154, 116, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(44, 44, 44, 0.52), rgba(44, 44, 44, 0.78));
+  color:#A6C8FF;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(184, 154, 116, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #B89A74;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(184, 154, 116, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(184, 154, 116, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(245, 247, 248, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #F5F7F8;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(245, 247, 248, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(245, 247, 248, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(166, 200, 255, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #A6C8FF;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(166, 200, 255, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(166, 200, 255, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(245, 247, 248, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #F5F7F8;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(245, 247, 248, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(245, 247, 248, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(184, 154, 116, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #B89A74;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(184, 154, 116, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(184, 154, 116, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(44, 44, 44, 0.24), rgba(44, 44, 44, 0.68));
+  border-top:3px solid #2C2C2C;
+  color:#A6C8FF;
+  box-shadow:0 12px 28px rgba(44, 44, 44, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(166, 200, 255, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#A6C8FF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(44, 44, 44, 0.14); color:#A6C8FF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(44, 44, 44, 0.16); border:2px solid rgba(44, 44, 44, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/spirited-away/theme.css
+++ b/skins-pro/spirited-away/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(194, 58, 74, 0.32), rgba(20, 24, 32, 0.62));
+  --sp-sidebar-bg: rgba(20, 24, 32, 0.88);
+  --sp-sidebar-text: #F5E6C9;
+  --sp-sidebar-text-muted: rgba(245, 230, 201, 0.68);
+  --sp-sidebar-active-bg: rgba(194, 58, 74, 0.26);
+  --sp-sidebar-active-text: #C23A4A;
+  --sp-text-primary: #F5E6C9;
+  --sp-text-main: #F5E6C9;
+  --sp-text-muted: rgba(245, 230, 201, 0.82);
+  --sp-text-muted-bright: rgba(245, 230, 201, 0.82);
+  --sp-text-muted-dim: rgba(245, 230, 201, 0.82);
+  --sp-text-stage:#F5E6C9;
+  --sp-text-stage-muted:rgba(245, 230, 201, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(194, 58, 74, 0.34) !important;
+  box-shadow:0 14px 42px rgba(20, 24, 32, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(194, 58, 74, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(194, 58, 74, 0.55) !important;
+  box-shadow:0 8px 22px rgba(20, 24, 32, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F5E6C9;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F5E6C9;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(245, 230, 201, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(245, 230, 201, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(245, 230, 201, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F5E6C9 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F5E6C9 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F5E6C9 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F5E6C9 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F5E6C9;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(245, 230, 201, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F5E6C9;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(245, 230, 201, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F5E6C9;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(245, 230, 201, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C23A4A; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(194, 58, 74, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(61, 107, 92, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(245, 230, 201, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(61, 107, 92, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(194, 58, 74, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(20, 24, 32, 0.48), rgba(20, 24, 32, 0.8));
+  color:#F5E6C9;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(194, 58, 74, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #C23A4A;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(194, 58, 74, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(194, 58, 74, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(61, 107, 92, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #3D6B5C;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(61, 107, 92, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(61, 107, 92, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(245, 230, 201, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #F5E6C9;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(245, 230, 201, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(245, 230, 201, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(61, 107, 92, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #3D6B5C;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(61, 107, 92, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(61, 107, 92, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(194, 58, 74, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #C23A4A;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(194, 58, 74, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(194, 58, 74, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(20, 24, 32, 0.28), rgba(20, 24, 32, 0.72));
+  border-top:3px solid #141820;
+  color:#F5E6C9;
+  box-shadow:0 12px 28px rgba(20, 24, 32, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(245, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C23A4A; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(245, 230, 201, 0.16); color:#F5E6C9; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(20, 24, 32, 0.14); border:2px solid rgba(245, 230, 201, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/stardew-valley/theme.css
+++ b/skins-pro/stardew-valley/theme.css
@@ -212,7 +212,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -250,7 +250,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -704,8 +704,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(126, 200, 80, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #FFF8E8;
+  --sp-sidebar-text-muted: rgba(255, 248, 232, 0.68);
+  --sp-sidebar-active-bg: rgba(126, 200, 80, 0.26);
+  --sp-sidebar-active-text: #7EC850;
+  --sp-text-primary: #FFF8E8;
+  --sp-text-main: #FFF8E8;
+  --sp-text-muted: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-bright: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-dim: rgba(255, 248, 232, 0.82);
+  --sp-text-stage:#FFF8E8;
+  --sp-text-stage-muted:rgba(255, 248, 232, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(126, 200, 80, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(126, 200, 80, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(126, 200, 80, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFF8E8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFF8E8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 248, 232, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFF8E8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFF8E8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFF8E8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFF8E8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFF8E8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 248, 232, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFF8E8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 248, 232, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFF8E8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 248, 232, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#7EC850; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(126, 200, 80, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(126, 200, 80, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#FFF8E8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(126, 200, 80, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7EC850;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(126, 200, 80, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(126, 200, 80, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #FFF8E8;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(255, 248, 232, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 232, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(126, 200, 80, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7EC850;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(126, 200, 80, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(126, 200, 80, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#7EC850; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/street-fighter-6/theme.css
+++ b/skins-pro/street-fighter-6/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(243, 156, 18, 0.32), rgba(26, 14, 8, 0.62));
+  --sp-sidebar-bg: rgba(26, 14, 8, 0.88);
+  --sp-sidebar-text: #FFF8E8;
+  --sp-sidebar-text-muted: rgba(255, 248, 232, 0.68);
+  --sp-sidebar-active-bg: rgba(243, 156, 18, 0.26);
+  --sp-sidebar-active-text: #F39C12;
+  --sp-text-primary: #FFF8E8;
+  --sp-text-main: #FFF8E8;
+  --sp-text-muted: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-bright: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-dim: rgba(255, 248, 232, 0.82);
+  --sp-text-stage:#FFF8E8;
+  --sp-text-stage-muted:rgba(255, 248, 232, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(243, 156, 18, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 14, 8, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(243, 156, 18, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(243, 156, 18, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 14, 8, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFF8E8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFF8E8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 248, 232, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFF8E8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFF8E8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFF8E8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFF8E8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFF8E8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 248, 232, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFF8E8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 248, 232, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFF8E8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 248, 232, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#F39C12; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(243, 156, 18, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(243, 156, 18, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 14, 8, 0.48), rgba(26, 14, 8, 0.8));
+  color:#FFF8E8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(243, 156, 18, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #F39C12;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(243, 156, 18, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(243, 156, 18, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #3498DB;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #FFF8E8;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(255, 248, 232, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 232, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #3498DB;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(243, 156, 18, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #F39C12;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(243, 156, 18, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(243, 156, 18, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 14, 8, 0.28), rgba(26, 14, 8, 0.72));
+  border-top:3px solid #1A0E08;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(26, 14, 8, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#F39C12; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 14, 8, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/teyvat-assets/theme.css
+++ b/skins-pro/teyvat-assets/theme.css
@@ -134,7 +134,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -166,7 +166,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -275,8 +275,214 @@ button { font:inherit; }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off { border-top:3px solid var(--sp-device-red); }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off { border-top:3px solid var(--sp-device-brown); }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(212, 152, 130, 0.18), rgba(11, 11, 11, 0.08));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.84);
+  --sp-sidebar-text: #1e2235;
+  --sp-sidebar-text-muted: rgba(30, 34, 53, 0.78);
+  --sp-sidebar-active-bg: rgba(212, 152, 130, 0.22);
+  --sp-sidebar-active-text: #d49882;
+  --sp-text-primary: #0B0B0B;
+  --sp-text-main: #0B0B0B;
+  --sp-text-muted: rgba(11, 11, 11, 0.72);
+  --sp-text-muted-bright: rgba(11, 11, 11, 0.72);
+  --sp-text-muted-dim: rgba(11, 11, 11, 0.72);
+  --sp-text-stage:#0B0B0B;
+  --sp-text-stage-muted:rgba(11, 11, 11, 0.58);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(212, 152, 130, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(212, 152, 130, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(212, 152, 130, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(18px) saturate(120%);
+  -webkit-backdrop-filter:blur(18px) saturate(120%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#1e2235;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#0B0B0B;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(11, 11, 11, 0.72) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(11, 11, 11, 0.72) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(11, 11, 11, 0.58) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#0B0B0B !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#0B0B0B !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#0B0B0B !important;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#0B0B0B !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#1e2235;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.device .muted, .camera-card .muted { color:rgba(30, 34, 53, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.device .status, .device .count-tag { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#0B0B0B;
+  text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(11, 11, 11, 0.58);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(255,255,255,.82);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#0B0B0B;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(11, 11, 11, 0.72);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#45c8d0; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(212, 152, 130, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(69, 200, 208, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(30, 34, 53, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(69, 200, 208, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(212, 152, 130, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.52), rgba(11, 11, 11, 0.78));
+  color:#1e2235;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(212, 152, 130, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #d49882;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(212, 152, 130, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(212, 152, 130, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(69, 200, 208, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #45c8d0;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(69, 200, 208, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(69, 200, 208, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(30, 34, 53, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #1e2235;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(30, 34, 53, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(30, 34, 53, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(69, 200, 208, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #45c8d0;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(69, 200, 208, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(69, 200, 208, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(212, 152, 130, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #d49882;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(212, 152, 130, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(212, 152, 130, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.24), rgba(11, 11, 11, 0.68));
+  border-top:3px solid #0B0B0B;
+  color:#1e2235;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.16);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(30, 34, 53, 0.84); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#1e2235; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(11, 11, 11, 0.14); color:#1e2235; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.16); border:2px solid rgba(11, 11, 11, 0.18); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

retro-luxury, romance-three-kingdoms, smarto-minimal, soft-home, spirited-away, stardew-valley, street-fighter-6, teyvat-assets

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [x] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [x] |

### 架构影响确认 / Architecture Impact

- [ ] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [x] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Batch 5/6 of the card text readability fix. Inject `skins-pro card theme port` into `theme.css` for 8 skins so muted labels and glass-card text stay legible.

Split from #40 because the combined diff exceeded Sourcery's 150k review limit.

### 附加信息 / Additional Info

Part of split series: fix/card-text-readability-1 .. fix/card-text-readability-6. Supersedes #40.