### PR TITLE
fix(skins): improve card text readability (batch 6/6)

### DIFF
--- a/skins-pro/tom-and-jerry/theme.css
+++ b/skins-pro/tom-and-jerry/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(52, 152, 219, 0.32), rgba(26, 26, 46, 0.62));
+  --sp-sidebar-bg: rgba(26, 26, 46, 0.88);
+  --sp-sidebar-text: #FFF8E8;
+  --sp-sidebar-text-muted: rgba(255, 248, 232, 0.68);
+  --sp-sidebar-active-bg: rgba(52, 152, 219, 0.26);
+  --sp-sidebar-active-text: #3498DB;
+  --sp-text-primary: #FFF8E8;
+  --sp-text-main: #FFF8E8;
+  --sp-text-muted: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-bright: rgba(255, 248, 232, 0.82);
+  --sp-text-muted-dim: rgba(255, 248, 232, 0.82);
+  --sp-text-stage:#FFF8E8;
+  --sp-text-stage-muted:rgba(255, 248, 232, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(52, 152, 219, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 26, 46, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(52, 152, 219, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(52, 152, 219, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 26, 46, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFF8E8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFF8E8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 248, 232, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 248, 232, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFF8E8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFF8E8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFF8E8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFF8E8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFF8E8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 248, 232, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFF8E8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 248, 232, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFF8E8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 248, 232, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#3498DB; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(230, 126, 34, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(230, 126, 34, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 26, 46, 0.48), rgba(26, 26, 46, 0.8));
+  color:#FFF8E8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #3498DB;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(230, 126, 34, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #E67E22;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(230, 126, 34, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(230, 126, 34, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 248, 232, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #FFF8E8;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(255, 248, 232, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 248, 232, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(230, 126, 34, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #E67E22;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(230, 126, 34, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(230, 126, 34, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(52, 152, 219, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #3498DB;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(52, 152, 219, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(52, 152, 219, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 26, 46, 0.28), rgba(26, 26, 46, 0.72));
+  border-top:3px solid #1A1A2E;
+  color:#FFF8E8;
+  box-shadow:0 12px 28px rgba(26, 26, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 248, 232, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#3498DB; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 248, 232, 0.16); color:#FFF8E8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 26, 46, 0.14); border:2px solid rgba(255, 248, 232, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/ultraman/theme.css
+++ b/skins-pro/ultraman/theme.css
@@ -150,7 +150,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -188,7 +188,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -478,8 +478,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(231, 76, 60, 0.32), rgba(10, 14, 32, 0.62));
+  --sp-sidebar-bg: rgba(10, 14, 32, 0.88);
+  --sp-sidebar-text: #F0F8FF;
+  --sp-sidebar-text-muted: rgba(240, 248, 255, 0.68);
+  --sp-sidebar-active-bg: rgba(231, 76, 60, 0.26);
+  --sp-sidebar-active-text: #E74C3C;
+  --sp-text-primary: #F0F8FF;
+  --sp-text-main: #F0F8FF;
+  --sp-text-muted: rgba(240, 248, 255, 0.82);
+  --sp-text-muted-bright: rgba(240, 248, 255, 0.82);
+  --sp-text-muted-dim: rgba(240, 248, 255, 0.82);
+  --sp-text-stage:#F0F8FF;
+  --sp-text-stage-muted:rgba(240, 248, 255, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(231, 76, 60, 0.34) !important;
+  box-shadow:0 14px 42px rgba(10, 14, 32, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(231, 76, 60, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(231, 76, 60, 0.55) !important;
+  box-shadow:0 8px 22px rgba(10, 14, 32, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F0F8FF;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F0F8FF;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(240, 248, 255, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(240, 248, 255, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(240, 248, 255, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F0F8FF !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F0F8FF !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F0F8FF !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F0F8FF !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F0F8FF;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(240, 248, 255, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F0F8FF;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(240, 248, 255, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F0F8FF;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(240, 248, 255, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#E74C3C; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(192, 192, 192, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(240, 248, 255, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(192, 192, 192, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(10, 14, 32, 0.48), rgba(10, 14, 32, 0.8));
+  color:#F0F8FF;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #E74C3C;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(231, 76, 60, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(231, 76, 60, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(192, 192, 192, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #C0C0C0;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(192, 192, 192, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(192, 192, 192, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(240, 248, 255, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #F0F8FF;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(240, 248, 255, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(240, 248, 255, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(192, 192, 192, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #C0C0C0;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(192, 192, 192, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(192, 192, 192, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(231, 76, 60, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #E74C3C;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(231, 76, 60, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(231, 76, 60, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(10, 14, 32, 0.28), rgba(10, 14, 32, 0.72));
+  border-top:3px solid #0A0E20;
+  color:#F0F8FF;
+  box-shadow:0 12px 28px rgba(10, 14, 32, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(240, 248, 255, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#E74C3C; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(240, 248, 255, 0.16); color:#F0F8FF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(10, 14, 32, 0.14); border:2px solid rgba(240, 248, 255, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/valorant/theme.css
+++ b/skins-pro/valorant/theme.css
@@ -49,15 +49,15 @@
   --sp-panel-bg:rgba(16, 20, 28, 0.82);
   --sp-card-bg:rgba(20,24,32,.82);
 
-  --sp-base-texture:url("./background.jpg");
-  --sp-stage-texture:url("./background.jpg");
+  --sp-base-texture:none;
+  --sp-stage-texture:none;
 
   --sp-app-overlay:
     radial-gradient(circle at 18% 8%, rgba(255,70,85,.20), transparent 30%),
     radial-gradient(circle at 82% 14%, rgba(38,211,255,.17), transparent 34%),
-    linear-gradient(135deg, rgba(8,11,16,.72) 0%, rgba(21,25,34,.55) 50%, rgba(8,11,16,.72) 100%);
+    linear-gradient(135deg,#080B10 0%,#151922 50%,#080B10 100%);
   --sp-stage-overlay:
-    linear-gradient(90deg, rgba(8,11,16,.42) 0%, rgba(8,11,16,.12) 38%, rgba(8,11,16,.48) 100%);
+    linear-gradient(90deg, rgba(8,11,16,.20) 0%, rgba(8,11,16,.00) 38%, rgba(8,11,16,.44) 100%);
   --sp-room-overlay:
     linear-gradient(180deg, transparent 28%, rgba(6,8,12,.84));
 
@@ -325,7 +325,7 @@ button { font:inherit; }
   border-radius:var(--sp-radius-glass);
   padding:var(--sp-space-lg);
   box-sizing:border-box;
-  background:var(--sp-glass-bg);
+  background:var(--sp-card-bg, var(--sp-glass-bg));
   backdrop-filter:blur(16px);
   -webkit-backdrop-filter:blur(16px);
   border:var(--sp-border-width) solid var(--sp-border-glass);
@@ -608,8 +608,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(255, 70, 85, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #F5F7FA;
+  --sp-sidebar-text-muted: rgba(245, 247, 250, 0.68);
+  --sp-sidebar-active-bg: rgba(255, 70, 85, 0.26);
+  --sp-sidebar-active-text: #FF4655;
+  --sp-text-primary: #F5F7FA;
+  --sp-text-main: #F5F7FA;
+  --sp-text-muted: rgba(245, 247, 250, 0.82);
+  --sp-text-muted-bright: rgba(245, 247, 250, 0.82);
+  --sp-text-muted-dim: rgba(245, 247, 250, 0.82);
+  --sp-text-stage:#F5F7FA;
+  --sp-text-stage-muted:rgba(245, 247, 250, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(255, 70, 85, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(255, 70, 85, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(255, 70, 85, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F5F7FA;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F5F7FA;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(245, 247, 250, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(245, 247, 250, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(245, 247, 250, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F5F7FA !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F5F7FA !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F5F7FA !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F5F7FA !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F5F7FA;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(245, 247, 250, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F5F7FA;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(245, 247, 250, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F5F7FA;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(245, 247, 250, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#FF4655; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(255, 70, 85, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(245, 247, 250, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(255, 70, 85, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F5F7FA;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(255, 70, 85, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #FF4655;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(255, 70, 85, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(255, 70, 85, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(245, 247, 250, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F5F7FA;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(245, 247, 250, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(245, 247, 250, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(255, 70, 85, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #FF4655;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(255, 70, 85, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(255, 70, 85, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#F5F7FA;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(245, 247, 250, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FF4655; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(245, 247, 250, 0.16); color:#F5F7FA; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(245, 247, 250, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/wall-e/theme.css
+++ b/skins-pro/wall-e/theme.css
@@ -123,7 +123,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -155,7 +155,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -345,8 +345,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(224, 123, 57, 0.32), rgba(26, 20, 8, 0.62));
+  --sp-sidebar-bg: rgba(26, 20, 8, 0.88);
+  --sp-sidebar-text: #FFD93D;
+  --sp-sidebar-text-muted: rgba(255, 217, 61, 0.68);
+  --sp-sidebar-active-bg: rgba(224, 123, 57, 0.26);
+  --sp-sidebar-active-text: #E07B39;
+  --sp-text-primary: #FFD93D;
+  --sp-text-main: #FFD93D;
+  --sp-text-muted: rgba(255, 217, 61, 0.82);
+  --sp-text-muted-bright: rgba(255, 217, 61, 0.82);
+  --sp-text-muted-dim: rgba(255, 217, 61, 0.82);
+  --sp-text-stage:#FFD93D;
+  --sp-text-stage-muted:rgba(255, 217, 61, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(224, 123, 57, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 20, 8, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(224, 123, 57, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(224, 123, 57, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 20, 8, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFD93D;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFD93D;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 217, 61, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 217, 61, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 217, 61, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFD93D !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFD93D !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFD93D !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFD93D !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFD93D;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 217, 61, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFD93D;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 217, 61, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFD93D;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 217, 61, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#E07B39; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(224, 123, 57, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(78, 205, 196, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 217, 61, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(78, 205, 196, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(224, 123, 57, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 20, 8, 0.48), rgba(26, 20, 8, 0.8));
+  color:#FFD93D;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(224, 123, 57, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #E07B39;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(224, 123, 57, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(224, 123, 57, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(78, 205, 196, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #4ECDC4;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(78, 205, 196, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(78, 205, 196, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 217, 61, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #FFD93D;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(255, 217, 61, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 217, 61, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(78, 205, 196, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #4ECDC4;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(78, 205, 196, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(78, 205, 196, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(224, 123, 57, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #E07B39;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(224, 123, 57, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(224, 123, 57, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 20, 8, 0.28), rgba(26, 20, 8, 0.72));
+  border-top:3px solid #1A1408;
+  color:#FFD93D;
+  box-shadow:0 12px 28px rgba(26, 20, 8, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 217, 61, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#E07B39; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 217, 61, 0.16); color:#FFD93D; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 20, 8, 0.14); border:2px solid rgba(255, 217, 61, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/warm-glass/theme.css
+++ b/skins-pro/warm-glass/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -250,8 +250,214 @@ button { font:inherit; }
   -webkit-backdrop-filter:blur(28px) saturate(200%);
 }
 .glass-card,.time-card { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(255, 149, 0, 0.32), rgba(26, 16, 8, 0.62));
+  --sp-sidebar-bg: rgba(26, 16, 8, 0.88);
+  --sp-sidebar-text: #FFD9A8;
+  --sp-sidebar-text-muted: rgba(255, 217, 168, 0.68);
+  --sp-sidebar-active-bg: rgba(255, 149, 0, 0.26);
+  --sp-sidebar-active-text: #FF9500;
+  --sp-text-primary: #FFD9A8;
+  --sp-text-main: #FFD9A8;
+  --sp-text-muted: rgba(255, 217, 168, 0.82);
+  --sp-text-muted-bright: rgba(255, 217, 168, 0.82);
+  --sp-text-muted-dim: rgba(255, 217, 168, 0.82);
+  --sp-text-stage:#FFD9A8;
+  --sp-text-stage-muted:rgba(255, 217, 168, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(255, 149, 0, 0.34) !important;
+  box-shadow:0 14px 42px rgba(26, 16, 8, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(255, 149, 0, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(255, 149, 0, 0.55) !important;
+  box-shadow:0 8px 22px rgba(26, 16, 8, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#FFD9A8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#FFD9A8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(255, 217, 168, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(255, 217, 168, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(255, 217, 168, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#FFD9A8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#FFD9A8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#FFD9A8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#FFD9A8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#FFD9A8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(255, 217, 168, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#FFD9A8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(255, 217, 168, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#FFD9A8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(255, 217, 168, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#FF9500; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(255, 149, 0, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(92, 58, 30, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(255, 217, 168, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(92, 58, 30, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(255, 149, 0, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(26, 16, 8, 0.48), rgba(26, 16, 8, 0.8));
+  color:#FFD9A8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(255, 149, 0, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #FF9500;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(255, 149, 0, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(255, 149, 0, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(92, 58, 30, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #5C3A1E;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(92, 58, 30, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(92, 58, 30, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(255, 217, 168, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #FFD9A8;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(255, 217, 168, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 217, 168, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(92, 58, 30, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #5C3A1E;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(92, 58, 30, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(92, 58, 30, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(255, 149, 0, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #FF9500;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(255, 149, 0, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(255, 149, 0, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(26, 16, 8, 0.28), rgba(26, 16, 8, 0.72));
+  border-top:3px solid #1A1008;
+  color:#FFD9A8;
+  box-shadow:0 12px 28px rgba(26, 16, 8, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 217, 168, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FF9500; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(255, 217, 168, 0.16); color:#FFD9A8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(26, 16, 8, 0.14); border:2px solid rgba(255, 217, 168, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }

--- a/skins-pro/witcher-3/theme.css
+++ b/skins-pro/witcher-3/theme.css
@@ -212,7 +212,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -250,7 +250,7 @@ button { font:inherit; }
 .room-scene-chip { pointer-events:auto; border:1px solid rgba(255,255,255,.2); border-radius:var(--sp-radius-pill); padding:4px 14px; background:rgba(0,0,0,.45); color:#fff; cursor:pointer; font-size:var(--sp-font-sm); font-weight:600; white-space:nowrap; text-align:right; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px); transition:background .2s; max-width:140px; overflow:hidden; text-overflow:ellipsis; }
 .room-scene-chip:hover { background:rgba(0,0,0,.60); }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -704,8 +704,214 @@ button { font:inherit; }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low { color:var(--sp-text-stage-muted,var(--sp-text-muted)); }
 .env-value,.energy-value,.maintenance-value { color:var(--sp-text-primary); }
 .chip { color:var(--sp-text-primary); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(192, 160, 96, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #E8DCC8;
+  --sp-sidebar-text-muted: rgba(232, 220, 200, 0.68);
+  --sp-sidebar-active-bg: rgba(192, 160, 96, 0.26);
+  --sp-sidebar-active-text: #C0A060;
+  --sp-text-primary: #E8DCC8;
+  --sp-text-main: #E8DCC8;
+  --sp-text-muted: rgba(232, 220, 200, 0.82);
+  --sp-text-muted-bright: rgba(232, 220, 200, 0.82);
+  --sp-text-muted-dim: rgba(232, 220, 200, 0.82);
+  --sp-text-stage:#E8DCC8;
+  --sp-text-stage-muted:rgba(232, 220, 200, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(192, 160, 96, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(192, 160, 96, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(192, 160, 96, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#E8DCC8;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#E8DCC8;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(232, 220, 200, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(232, 220, 200, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(232, 220, 200, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#E8DCC8 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#E8DCC8 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#E8DCC8 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#E8DCC8 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#E8DCC8;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(232, 220, 200, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#E8DCC8;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(232, 220, 200, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#E8DCC8;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(232, 220, 200, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#C0A060; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(192, 160, 96, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
 
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(232, 220, 200, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(192, 160, 96, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#E8DCC8;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(192, 160, 96, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C0A060;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(192, 160, 96, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(192, 160, 96, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(232, 220, 200, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #E8DCC8;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(232, 220, 200, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(232, 220, 200, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(192, 160, 96, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #C0A060;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(192, 160, 96, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(192, 160, 96, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#E8DCC8;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(232, 220, 200, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#C0A060; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(232, 220, 200, 0.16); color:#E8DCC8; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(232, 220, 200, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .weather-with-meta { display:flex; align-items:flex-start; margin-top:var(--sp-space-md,12px); }

--- a/skins-pro/world-cup-championship-night/theme.css
+++ b/skins-pro/world-cup-championship-night/theme.css
@@ -102,7 +102,7 @@ button { font:inherit; }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
 .security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-panel-bg); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
 .camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
@@ -134,7 +134,7 @@ button { font:inherit; }
 .room::after { content:""; position:absolute; inset:0; background:var(--sp-room-overlay); }
 .room-label { position:absolute; z-index:1; left:14px; right:14px; bottom:14px; text-align:left; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
-.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-glass-bg); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
+.glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
 .panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
@@ -286,6 +286,214 @@ button { font:inherit; }
 }
 .scene.morning { background: rgba(34, 197, 94, 0.22); }
 .scene.game { background: rgba(212, 175, 55, 0.24); }
+/* skins-pro card theme port */
+:host {
+  --sp-card-bg: linear-gradient(145deg, rgba(212, 175, 55, 0.32), rgba(11, 11, 11, 0.62));
+  --sp-sidebar-bg: rgba(11, 11, 11, 0.88);
+  --sp-sidebar-text: #F2E6C9;
+  --sp-sidebar-text-muted: rgba(242, 230, 201, 0.68);
+  --sp-sidebar-active-bg: rgba(212, 175, 55, 0.26);
+  --sp-sidebar-active-text: #D4AF37;
+  --sp-text-primary: #F2E6C9;
+  --sp-text-main: #F2E6C9;
+  --sp-text-muted: rgba(242, 230, 201, 0.82);
+  --sp-text-muted-bright: rgba(242, 230, 201, 0.82);
+  --sp-text-muted-dim: rgba(242, 230, 201, 0.82);
+  --sp-text-stage:#F2E6C9;
+  --sp-text-stage-muted:rgba(242, 230, 201, 0.72);
+}
+.sidebar {
+  background:var(--sp-sidebar-bg) !important;
+  border-color:rgba(212, 175, 55, 0.34) !important;
+  box-shadow:0 14px 42px rgba(11, 11, 11, 0.42) !important;
+}
+.nav-button {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:700 !important;
+  font-size:var(--sp-font-sm);
+}
+.nav-button ha-icon { color:inherit !important; opacity:0.92; }
+.nav-button:hover,
+.nav-button.active {
+  color:var(--sp-sidebar-active-text) !important;
+  background:var(--sp-sidebar-active-bg) !important;
+  box-shadow:inset 0 0 0 1px rgba(212, 175, 55, 0.42);
+}
+.profile .meta h3 {
+  color:var(--sp-sidebar-text) !important;
+  font-weight:700;
+}
+.profile .meta .muted {
+  color:var(--sp-sidebar-text-muted) !important;
+  font-weight:600;
+}
+.profile-img {
+  border-color:rgba(212, 175, 55, 0.55) !important;
+  box-shadow:0 8px 22px rgba(11, 11, 11, 0.35) !important;
+}
+.stage { background-color:transparent !important; }
+.devices .device, .devices-page-grid .device {
+  backdrop-filter:blur(28px) saturate(200%);
+  -webkit-backdrop-filter:blur(28px) saturate(200%);
+}
+.device, .camera-card {
+  background:var(--sp-card-bg, var(--sp-panel-bg));
+  color:#F2E6C9;
+  border-color:var(--sp-border-glass);
+}
+.glass-card, .time-card {
+  background:var(--sp-card-bg, var(--sp-glass-bg));
+  color:#F2E6C9;
+}
+.glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
+  color:rgba(242, 230, 201, 0.82) !important;
+}
+.muted, .device .muted, .camera-card .muted, .room-label .muted {
+  color:rgba(242, 230, 201, 0.82) !important;
+}
+.quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
+  color:rgba(242, 230, 201, 0.72) !important;
+  font-weight:600;
+}
+.chip, .chip-group .chip {
+  color:#F2E6C9 !important;
+  font-weight:600;
+}
+.chip.active {
+  color:#F2E6C9 !important;
+}
+.welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
+  color:#F2E6C9 !important;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+}
+.room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
+  color:#F2E6C9 !important;
+  font-weight:700;
+}
+.device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
+  color:#F2E6C9;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.device .muted, .camera-card .muted { color:rgba(242, 230, 201, 0.82); text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.device .status, .device .count-tag { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
+  color:#F2E6C9;
+  text-shadow:0 1px 6px rgba(0,0,0,.55),0 2px 12px rgba(0,0,0,.35);
+  font-weight:700;
+}
+.welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
+  color:rgba(242, 230, 201, 0.72);
+  font-weight:600;
+  text-shadow:0 1px 4px rgba(0,0,0,.45);
+}
+.env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
+  color:#F2E6C9;
+  font-weight:700;
+}
+.time-sub,.energy-value small,.energy-footer,.down {
+  color:rgba(242, 230, 201, 0.82);
+  font-weight:600;
+}
+.env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
+.energy-value { color:#D4AF37; }
+.scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
+
+.device-on-yellow {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-green {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-blue {
+  background:linear-gradient(165deg, rgba(242, 230, 201, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-purple {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-red {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.device-on-brown {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.48), rgba(11, 11, 11, 0.8));
+  color:#F2E6C9;
+}
+
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #D4AF37;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(212, 175, 55, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(212, 175, 55, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
+  background:linear-gradient(165deg, rgba(242, 230, 201, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #F2E6C9;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(242, 230, 201, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(242, 230, 201, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
+  background:linear-gradient(165deg, rgba(122, 92, 46, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #7A5C2E;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(122, 92, 46, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(122, 92, 46, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
+  background:linear-gradient(165deg, rgba(212, 175, 55, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #D4AF37;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(212, 175, 55, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(212, 175, 55, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
+  background:linear-gradient(165deg, rgba(11, 11, 11, 0.28), rgba(11, 11, 11, 0.72));
+  border-top:3px solid #0B0B0B;
+  color:#F2E6C9;
+  box-shadow:0 12px 28px rgba(11, 11, 11, 0.14);
+}
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(242, 230, 201, 0.82); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#D4AF37; font-weight:700; text-shadow:0 1px 4px rgba(0,0,0,.45); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(242, 230, 201, 0.16); color:#F2E6C9; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(11, 11, 11, 0.14); border:2px solid rgba(242, 230, 201, 0.16); }
+/* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
 .welcome-group { grid-area:welcome; display:block; min-width:0; }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

tom-and-jerry, ultraman, valorant, wall-e, warm-glass, witcher-3, world-cup-championship-night

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [x] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [x] |

### 架构影响确认 / Architecture Impact

- [ ] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [x] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Batch 6/6 of the card text readability fix. Inject `skins-pro card theme port` into `theme.css` for 7 skins so muted labels and glass-card text stay legible.

Split from #40 because the combined diff exceeded Sourcery's 150k review limit.

### 附加信息 / Additional Info

Part of split series: fix/card-text-readability-1 .. fix/card-text-readability-6. Supersedes #40.