### PR TITLE
fix(skins): repair ios-27-light media cover and layout (fixes #32)

### DIFF
--- a/skins-pro/ios-27-light/theme.css
+++ b/skins-pro/ios-27-light/theme.css
@@ -98,13 +98,15 @@ button { font:inherit; }
 .chip { min-height:36px; border:var(--sp-border-width) solid var(--sp-border-chip); border-radius:var(--sp-radius-pill); padding:0 14px; background:var(--sp-glass-dim); color:var(--sp-text-main); cursor:pointer; transition:all .2s ease; }
 .chip.active { background:var(--sp-accent-green-active); border-color:var(--sp-accent-green-border); color:var(--sp-accent-green); }
 .device-group { display:grid; gap:var(--sp-space-md); margin-bottom:var(--sp-space-lg); }
-.devices-page-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
+.devices-page-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
 .section-title { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-space-sm); }
 .devices { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); gap:var(--sp-space-md); }
-.security-grid { grid-template-columns:repeat(3,minmax(0,1fr)); gap:var(--sp-space-sm); }
-.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); }
+.security-grid { display:flex; flex-direction:column; gap:var(--sp-space-sm); }
+.security-cameras { display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:var(--sp-space-sm); }
+.security-devices { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:var(--sp-space-sm); }
+.device { min-height:148px; border:0; border-radius:var(--sp-radius-device); padding:var(--sp-space-lg); background:var(--sp-card-bg, var(--sp-panel-bg)); color:var(--sp-text-dark); box-shadow:var(--sp-shadow-card); display:grid; grid-template-rows:auto 1fr auto; cursor:pointer; text-align:left; border:var(--sp-border-width) solid var(--sp-border-device); overflow:hidden; }
 .camera-card { border:0; border-radius:var(--sp-radius-lg); overflow:hidden; background:var(--sp-panel-bg); color:var(--sp-text-dark); cursor:pointer; text-align:left; box-shadow:var(--sp-shadow-card); width:100%; }
-.camera-preview { aspect-ratio:16/10; background:var(--sp-camera-bg); }
+.camera-preview { aspect-ratio:3/2; background:var(--sp-camera-bg); min-height:100px; max-height:200px; }
 .camera-preview img { width:100%; height:100%; object-fit:cover; display:block; }
 .camera-meta { display:flex; justify-content:space-between; align-items:center; gap:var(--sp-space-md); padding:14px; }
 .devices-page-grid .device { min-height:110px; padding:var(--sp-space-sm); }
@@ -136,7 +138,42 @@ button { font:inherit; }
 .side { grid-area:side; min-height:0; height:100%; display:grid; grid-template-rows:max-content max-content minmax(0,1fr) minmax(0,1fr); gap:var(--sp-space-lg); align-content:stretch; overflow:hidden; }
 .glass-card,.time-card { border-radius:var(--sp-radius-glass); padding:var(--sp-space-lg); box-sizing:border-box; background:var(--sp-card-bg, var(--sp-glass-bg)); backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); border:var(--sp-border-width) solid var(--sp-border-glass); box-shadow:var(--sp-shadow-glass); color:var(--sp-text-main); }
 .side > section { min-height:0; }
-.panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
+.panel-energy { width:100%; max-width:100%; min-width:0; justify-self:stretch; align-self:stretch; min-height:0; height:auto; overflow:hidden; display:flex; flex-direction:column; }
+
+/* ---- Media Player (sidebar) ---- */
+.panel-media {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  justify-self: stretch;
+  align-self: stretch;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.media-content { display:flex; flex-direction:column; margin-top:var(--sp-space-xs); }
+.media-row { display:flex; align-items:center; gap:var(--sp-space-xs); }
+.media-volrow { margin-top:var(--sp-space-3xs); }
+.media-cover { width:48px; height:48px; border-radius:var(--sp-radius-sm); overflow:hidden; flex-shrink:0; }
+.media-cover img { width:100%; height:100%; object-fit:cover; display:block; }
+.media-cover-null { display:flex; align-items:center; justify-content:center; background:var(--sp-item-icon-bg); color:var(--sp-text-muted); }
+.media-cover-null ha-icon { --mdc-icon-size:22px; }
+.media-body { min-width:0; flex:1; }
+.media-title { font-size:var(--sp-font-xs); font-weight:700; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.media-artist,.media-source { font-size:var(--sp-font-3xs); color:var(--sp-text-muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.media-actions { display:flex; align-items:center; justify-content:center; gap:var(--sp-space-xs); flex-shrink:0; }
+.media-btn,.media-volbtn { background:none; border:none; color:var(--sp-text-primary); cursor:pointer; padding:6px; border-radius:50%; display:flex; align-items:center; justify-content:center; min-height:auto; width:auto; }
+.media-btn:hover,.media-volbtn:hover { background:var(--sp-glass-dim); }
+.media-btn ha-icon { --mdc-icon-size:24px; }
+.media-playbtn ha-icon { --mdc-icon-size:36px; }
+.media-volume { display:flex; align-items:center; gap:var(--sp-space-xs); }
+.media-volbtn ha-icon { --mdc-icon-size:20px; }
+.media-voltrack { flex:1; height:10px; border-radius:5px; background:var(--sp-glass-dim); overflow:hidden; cursor:pointer; position:relative; }
+.media-volfill { height:100%; border-radius:5px; background:var(--sp-text-muted); pointer-events:none; }
+.media-off-state { display:flex; align-items:center; gap:var(--sp-space-xs); margin-top:var(--sp-space-xs); color:var(--sp-text-muted); font-size:var(--sp-font-xs); }
+.media-off-state ha-icon { --mdc-icon-size:16px; }
+.media-toggle-icon { --mdc-icon-size:18px; color:var(--sp-text-primary); display:flex; }
+
 .panel-scenes { min-height:0; height:100%; overflow:hidden; display:flex; flex-direction:column; }
 .panel-scenes .scene-grid { min-height:0; flex:1; align-content:start; }
 .time-card { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-space-md); }
@@ -252,24 +289,24 @@ button { font:inherit; }
 .glass-card,.time-card { color:var(--sp-text-primary); }
 /* skins-pro card theme port */
 :host {
-  --sp-card-bg: linear-gradient(145deg, rgba(0, 122, 255, 0.18), rgba(242, 242, 247, 0.08));
-  --sp-sidebar-bg: rgba(242, 242, 247, 0.84);
+  --sp-card-bg: linear-gradient(145deg, rgba(0, 122, 255, 0.18), rgba(28, 28, 30, 0.08));
+  --sp-sidebar-bg: rgba(28, 28, 30, 0.84);
   --sp-sidebar-text: #FFFFFF;
   --sp-sidebar-text-muted: rgba(255, 255, 255, 0.78);
   --sp-sidebar-active-bg: rgba(0, 122, 255, 0.22);
   --sp-sidebar-active-text: #007AFF;
-  --sp-text-primary: #F2F2F7;
-  --sp-text-main: #F2F2F7;
-  --sp-text-muted: rgba(242, 242, 247, 0.72);
-  --sp-text-muted-bright: rgba(242, 242, 247, 0.72);
-  --sp-text-muted-dim: rgba(242, 242, 247, 0.72);
-  --sp-text-stage:#F2F2F7;
-  --sp-text-stage-muted:rgba(242, 242, 247, 0.58);
+  --sp-text-primary: #1C1C1E;
+  --sp-text-main: #1C1C1E;
+  --sp-text-muted: rgba(28, 28, 30, 0.72);
+  --sp-text-muted-bright: rgba(28, 28, 30, 0.72);
+  --sp-text-muted-dim: rgba(28, 28, 30, 0.72);
+  --sp-text-stage:#1C1C1E;
+  --sp-text-stage-muted:rgba(28, 28, 30, 0.58);
 }
 .sidebar {
   background:var(--sp-sidebar-bg) !important;
   border-color:rgba(0, 122, 255, 0.34) !important;
-  box-shadow:0 14px 42px rgba(242, 242, 247, 0.42) !important;
+  box-shadow:0 14px 42px rgba(28, 28, 30, 0.42) !important;
 }
 .nav-button {
   color:var(--sp-sidebar-text-muted) !important;
@@ -293,7 +330,7 @@ button { font:inherit; }
 }
 .profile-img {
   border-color:rgba(0, 122, 255, 0.55) !important;
-  box-shadow:0 8px 22px rgba(242, 242, 247, 0.35) !important;
+  box-shadow:0 8px 22px rgba(28, 28, 30, 0.35) !important;
 }
 .stage { background-color:transparent !important; }
 .devices .device, .devices-page-grid .device {
@@ -307,31 +344,31 @@ button { font:inherit; }
 }
 .glass-card, .time-card {
   background:var(--sp-card-bg, var(--sp-glass-bg));
-  color:#F2F2F7;
+  color:#1C1C1E;
 }
 .glass-card .muted, .time-card .muted, .panel-energy .muted, .panel-scenes .muted, .maintenance-card .muted {
-  color:rgba(242, 242, 247, 0.72) !important;
+  color:rgba(28, 28, 30, 0.72) !important;
 }
 .muted, .device .muted, .camera-card .muted, .room-label .muted {
-  color:rgba(242, 242, 247, 0.72) !important;
+  color:rgba(28, 28, 30, 0.72) !important;
 }
 .quote, .weather-current-cond, .forecast-weekday, .forecast-low, .time-sub, .maintenance-item, .section-title .muted, .scene .muted, .energy-value small, .energy-footer, .down {
-  color:rgba(242, 242, 247, 0.58) !important;
+  color:rgba(28, 28, 30, 0.58) !important;
   font-weight:600;
 }
 .chip, .chip-group .chip {
-  color:#F2F2F7 !important;
+  color:#1C1C1E !important;
   font-weight:600;
 }
 .chip.active {
-  color:#F2F2F7 !important;
+  color:#1C1C1E !important;
 }
 .welcome h1, .page-header h1, .section-title h2, .side h2, .side h3 {
-  color:#F2F2F7 !important;
+  color:#1C1C1E !important;
   text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
 }
 .room-label, .room-label h3, .device-name, .state-word, .page-header .muted {
-  color:#F2F2F7 !important;
+  color:#1C1C1E !important;
   font-weight:700;
 }
 .device .device-name, .device .state-word, .device-on-yellow, .device-on-green, .device-on-blue, .device-on-purple, .device-on-red, .device-on-brown {
@@ -339,23 +376,23 @@ button { font:inherit; }
   text-shadow:0 1px 4px rgba(255,255,255,.82);
 }
 .device .muted, .camera-card .muted { color:rgba(255, 255, 255, 0.84); text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.device .status, .device .count-tag { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
+.device .status, .device .count-tag { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
 .welcome h1,.welcome .quote,.weather-current-temp,.weather-current-hl,.weather-current-cond,.forecast-high,.forecast-low,.forecast-weekday {
-  color:#F2F2F7;
+  color:#1C1C1E;
   text-shadow:0 1px 4px rgba(255,255,255,.92),0 2px 14px rgba(255,255,255,.65);
   font-weight:700;
 }
 .welcome .quote,.weather-current-cond,.forecast-weekday,.forecast-low {
-  color:rgba(242, 242, 247, 0.58);
+  color:rgba(28, 28, 30, 0.58);
   font-weight:600;
   text-shadow:0 1px 4px rgba(255,255,255,.82);
 }
 .env-value,.energy-value,.maintenance-value,.time-main,.maintenance-item,.section-title h2,.panel-scenes .scene,.scene {
-  color:#F2F2F7;
+  color:#1C1C1E;
   font-weight:700;
 }
 .time-sub,.energy-value small,.energy-footer,.down {
-  color:rgba(242, 242, 247, 0.72);
+  color:rgba(28, 28, 30, 0.72);
   font-weight:600;
 }
 .env-value,.energy-value,.maintenance-value,.time-main { font-weight:700; }
@@ -363,100 +400,100 @@ button { font:inherit; }
 .scene ha-icon,.devices-page-grid .item-icon ha-icon { color:var(--sp-accent, var(--sp-accent-green)); font-size:28px; }
 
 .device-on-yellow {
-  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .device-on-green {
-  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .device-on-blue {
-  background:linear-gradient(165deg, rgba(255, 255, 255, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .device-on-purple {
-  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .device-on-red {
-  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .device-on-brown {
-  background:linear-gradient(165deg, rgba(242, 242, 247, 0.52), rgba(242, 242, 247, 0.78));
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.52), rgba(28, 28, 30, 0.78));
   color:#FFFFFF;
 }
 
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off {
-  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(242, 242, 247, 0.68));
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(28, 28, 30, 0.68));
   border-top:3px solid #007AFF;
   color:#FFFFFF;
   box-shadow:0 12px 28px rgba(0, 122, 255, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+1), .devices-page-grid > .device.device-off:nth-child(6n+1), .device.tone-yellow.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off {
-  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(242, 242, 247, 0.68));
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(28, 28, 30, 0.68));
   border-top:3px solid #C7C7CC;
   color:#FFFFFF;
   box-shadow:0 12px 28px rgba(199, 199, 204, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+2), .devices-page-grid > .device.device-off:nth-child(6n+2), .device.tone-green.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off {
-  background:linear-gradient(165deg, rgba(255, 255, 255, 0.24), rgba(242, 242, 247, 0.68));
+  background:linear-gradient(165deg, rgba(255, 255, 255, 0.24), rgba(28, 28, 30, 0.68));
   border-top:3px solid #FFFFFF;
   color:#FFFFFF;
   box-shadow:0 12px 28px rgba(255, 255, 255, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 255, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+3), .devices-page-grid > .device.device-off:nth-child(6n+3), .device.tone-blue.device-off .item-img { box-shadow:0 8px 16px rgba(255, 255, 255, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off {
-  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(242, 242, 247, 0.68));
+  background:linear-gradient(165deg, rgba(199, 199, 204, 0.24), rgba(28, 28, 30, 0.68));
   border-top:3px solid #C7C7CC;
   color:#FFFFFF;
   box-shadow:0 12px 28px rgba(199, 199, 204, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+4), .devices-page-grid > .device.device-off:nth-child(6n+4), .device.tone-purple.device-off .item-img { box-shadow:0 8px 16px rgba(199, 199, 204, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off {
-  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(242, 242, 247, 0.68));
+  background:linear-gradient(165deg, rgba(0, 122, 255, 0.24), rgba(28, 28, 30, 0.68));
   border-top:3px solid #007AFF;
   color:#FFFFFF;
   box-shadow:0 12px 28px rgba(0, 122, 255, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+5), .devices-page-grid > .device.device-off:nth-child(6n+5), .device.tone-red.device-off .item-img { box-shadow:0 8px 16px rgba(0, 122, 255, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off {
-  background:linear-gradient(165deg, rgba(242, 242, 247, 0.24), rgba(242, 242, 247, 0.68));
-  border-top:3px solid #F2F2F7;
+  background:linear-gradient(165deg, rgba(28, 28, 30, 0.24), rgba(28, 28, 30, 0.68));
+  border-top:3px solid #1C1C1E;
   color:#FFFFFF;
-  box-shadow:0 12px 28px rgba(242, 242, 247, 0.16);
+  box-shadow:0 12px 28px rgba(28, 28, 30, 0.16);
 }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .muted { color:rgba(255, 255, 255, 0.84); }
 .devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .state-word { color:#FFFFFF; font-weight:700; text-shadow:0 1px 4px rgba(255,255,255,.82); }
-.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(242, 242, 247, 0.14); color:#FFFFFF; }
-.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(242, 242, 247, 0.16); border:2px solid rgba(242, 242, 247, 0.18); }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .status { background:rgba(28, 28, 30, 0.14); color:#FFFFFF; }
+.devices > .device.device-off:nth-child(6n+6), .devices-page-grid > .device.device-off:nth-child(6n+6), .device.tone-brown.device-off .item-img { box-shadow:0 8px 16px rgba(28, 28, 30, 0.16); border:2px solid rgba(28, 28, 30, 0.18); }
 /* end skins-pro card theme port */
 
 /* skins-pro weather layout patch */
@@ -799,7 +836,7 @@ button { font:inherit; }
   --sp-glass-bg: rgba(255, 255, 255, 0.52);
   --sp-panel-bg: rgba(255, 255, 255, 0.36);
   --sp-app-overlay: linear-gradient(135deg, rgba(242, 242, 247, 0.72) 0%, rgba(229, 240, 255, 0.55) 48%, rgba(255, 255, 255, 0.42) 100%);
-  --sp-stage-overlay: linear-gradient(135deg, rgba(255,255,255,0.28) 0%, rgba(0,122,255,0.08) 55%, rgba(242,242,247,0.18) 100%);
+  --sp-stage-overlay: none;
   --sp-room-overlay: linear-gradient(180deg, transparent 45%, rgba(28,28,30,0.28));
   --sp-text-primary: #1C1C1E;
   --sp-text-main: #1C1C1E;
@@ -864,19 +901,43 @@ button { font:inherit; }
 .sidebar,
 .glass-card,
 .time-card,
-.welcome,
 .weather-row {
   backdrop-filter: blur(28px) saturate(1.35);
   -webkit-backdrop-filter: blur(28px) saturate(1.35);
 }
+.welcome,
+.welcome-group {
+  background: transparent !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+.sidebar {
+  background: var(--sp-glass-bg) !important;
+  border-color: var(--sp-border-glass) !important;
+  box-shadow: var(--sp-shadow-md) !important;
+}
+.nav-button {
+  color: var(--sp-text-muted) !important;
+}
 .nav-button.active,
 .nav-button:hover {
-  color: #007AFF;
-  background: rgba(0, 122, 255, 0.12);
+  color: #007AFF !important;
+  background: rgba(0, 122, 255, 0.12) !important;
+  box-shadow: none !important;
+}
+.profile .meta h3 {
+  color: var(--sp-text-main) !important;
+}
+.profile .meta .muted {
+  color: var(--sp-text-muted) !important;
 }
 .mc-app {
   background-image: var(--sp-app-overlay), var(--sp-base-texture);
   background-size: cover, cover;
   background-position: center, center;
   background-repeat: no-repeat, no-repeat;
+}
+.stage {
+  background-color: transparent !important;
+  background-image: var(--sp-stage-texture) !important;
 }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

ios-27-light

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [x] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [x] |

### 架构影响确认 / Architecture Impact

- [x] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [ ] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Fixes #32 for **ios-27-light**:

- Add missing `.media-cover` sidebar styles so album art stays in bounds
- Restore security page layout (`.security-grid` / `.security-cameras` / `.security-devices`)
- Regenerate card theme port with correct bright `ui_mode` (dark text on light glass)
- Remove welcome-area backdrop block; keep blur on weather row and cards only
- Restore light-glass sidebar appearance after card-theme patch

### 附加信息 / Additional Info

Addresses layout issues reported in https://github.com/ha-china/Skins-Pro/issues/32
