### PR TITLE
feat: add Prism Tide dark mode support

### DIFF
--- a/scripts/build-skins.cjs
+++ b/scripts/build-skins.cjs
@@ -61,7 +61,7 @@ function getResizeOptions(filename) {
   if (name.startsWith('decor')) {
     return { height: 400, fit: 'inside' };
   }
-  if (name.startsWith('base-') || name.startsWith('stage-') || name.startsWith('background.')) {
+  if (name.startsWith('base-') || name.startsWith('stage-') || name.startsWith('background.') || name.startsWith('background-')) {
     return { width: 2560 };
   }
   return { width: 1200 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -268,7 +268,7 @@ export function selectedSkin(config?: DashboardConfig): string {
   return matchedSkin || DEFAULT_SKIN;
 }
 
-const DARK_SUPPORTED_SKINS = new Set(['modern', 'neo-tactile']);
+const DARK_SUPPORTED_SKINS = new Set(['modern', 'neo-tactile', 'prism-tide']);
 export function skinSupportsDark(skin: string): boolean {
   return DARK_SUPPORTED_SKINS.has(skin);
 }


### PR DESCRIPTION
### 类型 / Type

- [x] 贡献主题 / Contribute a Skin
- [ ] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

Prism Tide (`prism-tide`)

### 皮肤提交检查 / Skin Submission Checklist

<!-- Not applicable to this architecture-only PR. -->

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [ ] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [ ] |

### 架构影响确认 / Architecture Impact

- [x] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [ ] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

- Register `prism-tide` in the existing dark-capable skin set so `skin_mode: auto/light/dark` can select its paired assets.
- Process `background-dark.*` with the same 2560 px build target as `background.*`; previously it fell through to the generic 1200 px rule.
- Keep the skin assets and preview screenshot in a separate skin-contribution PR so the repository path restrictions remain satisfied.

### 附加信息 / Additional Info

Validated on Skins-Pro 2.2.8 (`a9c87c24629af81029709ec8d900e054965f05a9`):

- `npm run type-check`
- `npm run build -- --skins-only`

No CSS variables or DOM structure are changed.
