### PR TITLE
feat: enable Suzhou Moon Garden dark mode

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -268,7 +268,7 @@ export function selectedSkin(config?: DashboardConfig): string {
   return matchedSkin || DEFAULT_SKIN;
 }
 
-const DARK_SUPPORTED_SKINS = new Set(['modern', 'neo-tactile', 'prism-tide']);
+const DARK_SUPPORTED_SKINS = new Set(['modern', 'neo-tactile', 'prism-tide', 'suzhou-moon-garden']);
 export function skinSupportsDark(skin: string): boolean {
   return DARK_SUPPORTED_SKINS.has(skin);
 }


### PR DESCRIPTION
### 类型 / Type

勾选适用的类别（可多选）/ Check all that apply:

- [ ] 贡献主题 / Contribute a Skin
- [x] 优化架构 / Architecture Optimization

### 皮肤名称 / Skin Name

Not applicable (paired with skin asset PR #189)

### 皮肤提交检查 / Skin Submission Checklist

| 检查项 / Check | 结果 / Result |
| --- | --- |
| 皮肤文件夹名称与 `screenshots/<skin>.png` 预览图名称一致 / Skin folder name matches `screenshots/<skin>.png` preview name | - [ ] |
| `skins-pro/<skin>/strings.json` 已包含 `author` 字段 / `skins-pro/<skin>/strings.json` includes `author` | - [ ] |

### 架构影响确认 / Architecture Impact

- [x] 此变更**不会**影响已有皮肤的显示（未改动 CSS 变量名、DOM 结构等） / This change does **not** affect existing skins
- [ ] 如可能有影响，我已随机验证至少 2 款非自己制作的皮肤显示正常 / If likely affected, I have verified at least 2 skins I did not create render correctly

### 描述 / Description

Add `suzhou-moon-garden` to the existing `DARK_SUPPORTED_SKINS` allowlist so the v1.0.1 skin in #189 can use its official `-dark` image variants and `data-sp-theme="dark"` CSS overrides. This follows the same one-line integration pattern used for Prism Tide in #183 and does not change the behavior of existing skins.

### 附加信息 / Additional Info

- Paired skin asset PR: #189.
- Based on the latest official `master` (`a2d0edf1`).
- `npm run type-check` passed on Skins-Pro 2.2.8.
- Real runtime verification confirmed `data-sp-theme="dark"`, all dark image assets loaded, a 1920×1080 app rect, no overflow, and no preview audit errors.
